### PR TITLE
Data fetching for Profile pages via FlowApiRequests

### DIFF
--- a/src/com/uwflow/flow_android/adapters/CourseReviewAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/CourseReviewAdapter.java
@@ -1,6 +1,7 @@
 package com.uwflow.flow_android.adapters;
 
 import android.content.Context;
+import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,10 +26,12 @@ import java.util.List;
 public class CourseReviewAdapter extends BaseAdapter {
     private List<Review> mReviews;
     private Context mContext;
+    private FragmentManager mFragmentManager;
 
-    public CourseReviewAdapter(List<Review> reviews, Context context) {
+    public CourseReviewAdapter(List<Review> reviews, Context context, FragmentManager fragmentManager) {
         mReviews = reviews;
         mContext = context;
+	mFragmentManager = fragmentManager;
     }
 
     public int getCount() {
@@ -101,7 +104,7 @@ public class CourseReviewAdapter extends BaseAdapter {
 
                     user.setId(review.getAuthor().getId());
                     user.setFirstName(FacebookUtilities.getFirstWord(review.getAuthor().getName()));
-                    FacebookUtilities.createUserDialog(mContext, user).show();
+		    FacebookUtilities.createUserDialog(mContext, user, R.id.content_frame, mFragmentManager).show();
                 }
             };
             image.setOnClickListener(onClickListener);

--- a/src/com/uwflow/flow_android/adapters/FriendListAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/FriendListAdapter.java
@@ -1,6 +1,7 @@
 package com.uwflow.flow_android.adapters;
 
 import android.content.Context;
+import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,10 +22,12 @@ import java.util.ArrayList;
 public class FriendListAdapter extends BaseAdapter {
     private ArrayList<CourseFriend> mList;
     private Context mContext;
+    private FragmentManager mFragmentManager;
 
-    public FriendListAdapter(ArrayList<CourseFriend> list, Context context) {
+    public FriendListAdapter(ArrayList<CourseFriend> list, Context context, FragmentManager fragmentManager) {
         mList = list;
         mContext = context;
+	mFragmentManager = fragmentManager;
     }
 
     public int getCount() {
@@ -67,7 +70,7 @@ public class FriendListAdapter extends BaseAdapter {
         View.OnClickListener onClickListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FacebookUtilities.createUserDialog(mContext, user).show();
+		FacebookUtilities.createUserDialog(mContext, user, R.id.content_frame, mFragmentManager).show();
             }
         };
         convertView.setOnClickListener(onClickListener);

--- a/src/com/uwflow/flow_android/adapters/ProfileFriendAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/ProfileFriendAdapter.java
@@ -1,6 +1,7 @@
 package com.uwflow.flow_android.adapters;
 
 import android.content.Context;
+import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,10 +18,12 @@ import java.util.List;
 public class ProfileFriendAdapter extends BaseAdapter {
     private List<User> mFriends;
     private Context mContext;
+    private FragmentManager mFragmentManager;
 
-    public ProfileFriendAdapter(List<User> friends, Context context) {
+    public ProfileFriendAdapter(List<User> friends, Context context, FragmentManager fragmentManager) {
         mFriends = friends;
         mContext = context;
+	mFragmentManager = fragmentManager;
     }
 
     public int getCount() {
@@ -55,7 +58,7 @@ public class ProfileFriendAdapter extends BaseAdapter {
         View.OnClickListener onClickListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FacebookUtilities.createUserDialog(mContext, user).show();
+		FacebookUtilities.createUserDialog(mContext, user, R.id.content_frame, mFragmentManager).show();
             }
         };
         convertView.setOnClickListener(onClickListener);

--- a/src/com/uwflow/flow_android/adapters/ProfilePagerAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/ProfilePagerAdapter.java
@@ -1,11 +1,14 @@
 package com.uwflow.flow_android.adapters;
 
+import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import com.uwflow.flow_android.fragment.*;
 
 public class ProfilePagerAdapter extends FragmentStatePagerAdapter {
+    private Bundle mBundle;
+
     private static final String[] TITLES = new String[] {
             "Friends",
             "Schedule",
@@ -13,19 +16,30 @@ public class ProfilePagerAdapter extends FragmentStatePagerAdapter {
             "Courses"
     };
 
-    public ProfilePagerAdapter(FragmentManager fm) {
+    public ProfilePagerAdapter(FragmentManager fm, Bundle bundle) {
         super(fm);
+	mBundle = bundle;
     }
 
     @Override
     public Fragment getItem(int position) {
+	Fragment fragment = null;
         switch (position){
-            case 0 : return new ProfileFriendFragment();
-            case 1 : return new ProfileScheduleFragment();
-            case 2 : return new ProfileExamFragment();
-            case 3 : return new ProfileCourseFragment();
-            default: return new AboutFragment();
+	    case 0 :
+		fragment = new ProfileFriendFragment();
+		break;
+	    case 1 :
+		fragment = new ProfileScheduleFragment();
+		break;
+	    case 2 :
+		fragment = new ProfileExamFragment();
+		break;
+	    case 3 :
+		fragment = new ProfileCourseFragment();
+		break;
         }
+	if (fragment != null) fragment.setArguments(mBundle);
+	return fragment;
     }
 
     @Override

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -58,6 +58,9 @@ public class Constants {
 
     public static final String UW_FLOW = "uwflow";
 
+    public static final String COURSE_ID_KEY = "course_id";
+    public static final String PROFILE_ID_KEY = "profile_id";
+
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;
     public static final int COURSE_ABOUT_PAGE_INDEX = 1;
     public static final int COURSE_REVIEWS_PAGE_INDEX = 2;

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -61,7 +61,6 @@ public class Constants {
     public static final String COURSE_ID_KEY = "course_id";
     public static final String COURSE_ID_DEFAULT = "econ101";
     public static final String PROFILE_ID_KEY = "profile_id";
-    public static final String PROFILE_ID_DEFAULT = "5061a8db44957127ebf1bc9a";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;
     public static final int COURSE_ABOUT_PAGE_INDEX = 1;

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -59,7 +59,9 @@ public class Constants {
     public static final String UW_FLOW = "uwflow";
 
     public static final String COURSE_ID_KEY = "course_id";
+    public static final String COURSE_ID_DEFAULT = "econ101";
     public static final String PROFILE_ID_KEY = "profile_id";
+    public static final String PROFILE_ID_DEFAULT = "5061a8db44957127ebf1bc9a";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;
     public static final int COURSE_ABOUT_PAGE_INDEX = 1;

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -26,9 +26,6 @@ public class Constants {
     public static final String API_USERS_FRIENDS = "api/v1/users/%s/friends";
     public static final String API_SEARCH_COURSES = "api/v1/search/courses?%s";
 
-    public static final String COURSE_ID_KEY = "courseId";
-
-
     public static class DatabaseColumnName{
         public static final String USER_ID = "user_id";
 
@@ -59,7 +56,6 @@ public class Constants {
     public static final String UW_FLOW = "uwflow";
 
     public static final String COURSE_ID_KEY = "course_id";
-    public static final String COURSE_ID_DEFAULT = "econ101";
     public static final String PROFILE_ID_KEY = "profile_id";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;

--- a/src/com/uwflow/flow_android/fragment/CourseAboutFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseAboutFragment.java
@@ -43,17 +43,17 @@ public class CourseAboutFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-	mCourseID = getArguments() != null ? getArguments().getString(Constants.COURSE_ID_KEY,
-		Constants.COURSE_ID_DEFAULT) : Constants.COURSE_ID_DEFAULT;
+        mCourseID = getArguments() != null ? getArguments().getString(Constants.COURSE_ID_KEY,
+                Constants.COURSE_ID_DEFAULT) : Constants.COURSE_ID_DEFAULT;
 
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.course_about, container, false);
 
         mFriendListContainer = (LinearLayout)rootView.findViewById(R.id.friend_list);
-	mFriendListTextView = (TextView)rootView.findViewById(R.id.friend_list_title);
+        mFriendListTextView = (TextView)rootView.findViewById(R.id.friend_list_title);
         mParentViewPager = (ViewPager)getActivity().findViewById(R.id.pager);
-	mDescTextView = (TextView)rootView.findViewById(R.id.course_desc);
-	mRatingOverviewLayout = (LinearLayout) rootView.findViewById(R.id.rating_overview);
+        mDescTextView = (TextView)rootView.findViewById(R.id.course_desc);
+        mRatingOverviewLayout = (LinearLayout) rootView.findViewById(R.id.rating_overview);
 
         // Configure "See individual reviews" button to point to the course reviews tab
         Button individualReviewsButton = (Button)rootView.findViewById(R.id.see_reviews_btn);
@@ -64,39 +64,39 @@ public class CourseAboutFragment extends Fragment {
             }
         });
 
-	return rootView;
+        return rootView;
     }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState){
-	super.onActivityCreated(savedInstanceState);
+        super.onActivityCreated(savedInstanceState);
 
-	fetchCourseFriends(mCourseID);
+        fetchCourseFriends(mCourseID);
     }
 
     public void loadCourseInfo(CourseDetail courseDetail) {
-	// TODO: null checking?
-	mCourseDetail = courseDetail;
+        // TODO: null checking?
+        mCourseDetail = courseDetail;
 
-	mDescTextView.setText(mCourseDetail.getDescription());
+        mDescTextView.setText(mCourseDetail.getDescription());
 
-	reloadRatingOverview();
+        reloadRatingOverview();
     }
 
     private void reloadRatingOverview() {
-	TextView overallRating = (TextView)mRatingOverviewLayout.findViewById(R.id.overall_rating);
-	TextView overallCount = (TextView)mRatingOverviewLayout.findViewById(R.id.overall_count);
-	ProgressBar usefulRating = (ProgressBar)mRatingOverviewLayout.findViewById(R.id.useful_bar);
-	TextView usefulCount = (TextView)mRatingOverviewLayout.findViewById(R.id.useful_count);
-	ProgressBar easyRating = (ProgressBar)mRatingOverviewLayout.findViewById(R.id.easy_bar);
-	TextView easyCount = (TextView)mRatingOverviewLayout.findViewById(R.id.easy_count);
+        TextView overallRating = (TextView)mRatingOverviewLayout.findViewById(R.id.overall_rating);
+        TextView overallCount = (TextView)mRatingOverviewLayout.findViewById(R.id.overall_count);
+        ProgressBar usefulRating = (ProgressBar)mRatingOverviewLayout.findViewById(R.id.useful_bar);
+        TextView usefulCount = (TextView)mRatingOverviewLayout.findViewById(R.id.useful_count);
+        ProgressBar easyRating = (ProgressBar)mRatingOverviewLayout.findViewById(R.id.easy_bar);
+        TextView easyCount = (TextView)mRatingOverviewLayout.findViewById(R.id.easy_count);
 
-	overallRating.setText(String.format("%d%%", (int)(mCourseDetail.getOverall().getRating() * 100)));
-	overallCount.setText(String.format("%d ratings", (int) mCourseDetail.getOverall().getCount()));
-	usefulRating.setProgress((int) (Double.valueOf(mCourseDetail.getRatings().get(Rating.USEFULNESS).getRating()) * 100));
-	usefulCount.setText(String.format("%d ratings", mCourseDetail.getRatings().get(Rating.USEFULNESS).getCount()));
-	easyRating.setProgress((int) (Double.valueOf(mCourseDetail.getRatings().get(Rating.EASINESS).getRating()) * 100));
-	easyCount.setText(String.format("%d ratings", mCourseDetail.getRatings().get(Rating.EASINESS).getCount()));
+        overallRating.setText(String.format("%d%%", (int)(mCourseDetail.getOverall().getRating() * 100)));
+        overallCount.setText(String.format("%d ratings", (int) mCourseDetail.getOverall().getCount()));
+        usefulRating.setProgress((int) (Double.valueOf(mCourseDetail.getRatings().get(Rating.USEFULNESS).getRating()) * 100));
+        usefulCount.setText(String.format("%d ratings", mCourseDetail.getRatings().get(Rating.USEFULNESS).getCount()));
+        easyRating.setProgress((int) (Double.valueOf(mCourseDetail.getRatings().get(Rating.EASINESS).getRating()) * 100));
+        easyCount.setText(String.format("%d ratings", mCourseDetail.getRatings().get(Rating.EASINESS).getCount()));
     }
 
 
@@ -108,7 +108,7 @@ public class CourseAboutFragment extends Fragment {
                     public void getCourseUsersCallback(CourseUserDetail courseUserDetail) {
                         ArrayList<CourseFriend> courseFriends = getConsolidatedCourseFriendList(courseUserDetail);
 
-                        mFriendListAdapter = new FriendListAdapter(courseFriends, getActivity(), getFragmentManager());
+                        mFriendListAdapter = new FriendListAdapter(courseFriends, getActivity(), getActivity().getSupportFragmentManager());
 
                         // Reload the TextView indicating the number of course friends
                         mFriendListTextView.setText(String.format("%d friends took this", mFriendListAdapter.getCount()));
@@ -125,39 +125,39 @@ public class CourseAboutFragment extends Fragment {
     }
 
     private ArrayList<CourseFriend> getConsolidatedCourseFriendList(CourseUserDetail courseUserDetail) {
-	HashMap<String, User> friendMap = new HashMap<String, User>();
+        HashMap<String, User> friendMap = new HashMap<String, User>();
 
-	// Insert all Users into a HashMap for fetching later
-	for (User user : courseUserDetail.getUsers()) {
-	    friendMap.put(user.getId(), user);
+        // Insert all Users into a HashMap for fetching later
+        for (User user : courseUserDetail.getUsers()) {
+            friendMap.put(user.getId(), user);
         }
 
-	// Sort list of terms in reverse order (most recent first)
-	ArrayList<TermUser> termUsers = courseUserDetail.getTermUsers();
-	Collections.sort(termUsers, new CourseUserTermComparator());
+        // Sort list of terms in reverse order (most recent first)
+        ArrayList<TermUser> termUsers = courseUserDetail.getTermUsers();
+        Collections.sort(termUsers, new CourseUserTermComparator());
 
-	// Create a list of course friends based on the sorted order above
-	ArrayList<CourseFriend> courseFriends = new ArrayList<CourseFriend>();
-	for (TermUser termUser : termUsers) {
-	    for (String userId : termUser.getUserIds()) {
-		courseFriends.add(new CourseFriend(termUser.getTermName(), friendMap.get(userId)));
-	    }
+        // Create a list of course friends based on the sorted order above
+        ArrayList<CourseFriend> courseFriends = new ArrayList<CourseFriend>();
+        for (TermUser termUser : termUsers) {
+            for (String userId : termUser.getUserIds()) {
+                courseFriends.add(new CourseFriend(termUser.getTermName(), friendMap.get(userId)));
+            }
         }
 
-	return courseFriends;
+        return courseFriends;
     }
 
     class CourseUserTermComparator implements Comparator<TermUser> {
 
-	public CourseUserTermComparator() {}
+        public CourseUserTermComparator() {}
 
-	public int compare(TermUser a, TermUser b) {
-	    if (a.getTermId().compareTo(b.getTermId()) > 0) {
-		return -1;
-	    } else {
-		return 1;
-	    }
-	}
+        public int compare(TermUser a, TermUser b) {
+            if (a.getTermId().compareTo(b.getTermId()) > 0) {
+                return -1;
+            } else {
+                return 1;
+            }
+        }
     }
 
 }

--- a/src/com/uwflow/flow_android/fragment/CourseAboutFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseAboutFragment.java
@@ -5,6 +5,7 @@ package com.uwflow.flow_android.fragment;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -43,8 +44,12 @@ public class CourseAboutFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        mCourseID = getArguments() != null ? getArguments().getString(Constants.COURSE_ID_KEY,
-                Constants.COURSE_ID_DEFAULT) : Constants.COURSE_ID_DEFAULT;
+        Bundle args = getArguments();
+        if (args != null) {
+            mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
+        } else {
+            Log.e(TAG, "CourseFragment created without bundle: cannot fetch course details.");
+        }
 
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.course_about, container, false);

--- a/src/com/uwflow/flow_android/fragment/CourseAboutFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseAboutFragment.java
@@ -27,6 +27,9 @@ import java.util.HashMap;
  */
 public class CourseAboutFragment extends Fragment {
     private static final String TAG = "CourseAboutFragment";
+
+    private String mCourseID;
+
     private BaseAdapter mFriendListAdapter;
     private LinearLayout mFriendListContainer;
     private TextView mFriendListTextView;
@@ -40,6 +43,9 @@ public class CourseAboutFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+	mCourseID = getArguments() != null ? getArguments().getString(Constants.COURSE_ID_KEY,
+		Constants.COURSE_ID_DEFAULT) : Constants.COURSE_ID_DEFAULT;
+
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.course_about, container, false);
 
@@ -65,7 +71,7 @@ public class CourseAboutFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState){
 	super.onActivityCreated(savedInstanceState);
 
-	fetchCourseFriends("psych101");
+	fetchCourseFriends(mCourseID);
     }
 
     public void loadCourseInfo(CourseDetail courseDetail) {
@@ -95,27 +101,27 @@ public class CourseAboutFragment extends Fragment {
 
 
     private void fetchCourseFriends(String course){
-	FlowApiRequests.getCourseUsers(
-            course,
-            new FlowApiRequestCallbackAdapter() {
-                @Override
-                public void getCourseUsersCallback(CourseUserDetail courseUserDetail) {
-                    ArrayList<CourseFriend> courseFriends = getConsolidatedCourseFriendList(courseUserDetail);
+        FlowApiRequests.getCourseUsers(
+                course,
+                new FlowApiRequestCallbackAdapter() {
+                    @Override
+                    public void getCourseUsersCallback(CourseUserDetail courseUserDetail) {
+                        ArrayList<CourseFriend> courseFriends = getConsolidatedCourseFriendList(courseUserDetail);
 
-                    mFriendListAdapter = new FriendListAdapter(courseFriends, getActivity());
+                        mFriendListAdapter = new FriendListAdapter(courseFriends, getActivity(), getFragmentManager());
 
-                    // Reload the TextView indicating the number of course friends
-                    mFriendListTextView.setText(String.format("%d friends took this", mFriendListAdapter.getCount()));
+                        // Reload the TextView indicating the number of course friends
+                        mFriendListTextView.setText(String.format("%d friends took this", mFriendListAdapter.getCount()));
 
-                    // Re-populate UI with new data
-                    mFriendListContainer.removeAllViews();
-                    for (int i = 0; i < mFriendListAdapter.getCount(); i++) {
-                        View item = mFriendListAdapter.getView(i, null, null);
+                        // Re-populate UI with new data
+                        mFriendListContainer.removeAllViews();
+                        for (int i = 0; i < mFriendListAdapter.getCount(); i++) {
+                            View item = mFriendListAdapter.getView(i, null, null);
 
-                        mFriendListContainer.addView(item);
+                            mFriendListContainer.addView(item);
+                        }
                     }
-                }
-            });
+                });
     }
 
     private ArrayList<CourseFriend> getConsolidatedCourseFriendList(CourseUserDetail courseUserDetail) {

--- a/src/com/uwflow/flow_android/fragment/CourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseFragment.java
@@ -81,6 +81,15 @@ public class CourseFragment extends Fragment {
                 mCourseAboutFragment,
                 mCourseReviewsFragment);
 
+        // TODO(david): Should show a spinner here while course info is loading
+        Bundle args = getArguments();
+        if (args != null) {
+            mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
+            fetchCourseInfo(mCourseID);
+        } else {
+            Log.e(TAG, "CourseFragment created without bundle: cannot fetch course details.");
+        }
+
         mViewPager = (ViewPager) rootView.findViewById(R.id.pager);
         mViewPager.setAdapter(mCoursePagerAdapter);
         mTabs.setViewPager(mViewPager);
@@ -123,20 +132,6 @@ public class CourseFragment extends Fragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState){
         super.onActivityCreated(savedInstanceState);
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        // TODO(david): Should show a spinner here while course info is loading
-        Bundle args = getArguments();
-        if (args != null) {
-            mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
-            fetchCourseInfo(mCourseID);
-        } else {
-            Log.e(TAG, "CourseFragment created without bundle: cannot fetch course details.");
-        }
     }
 
     private void fetchCourseInfo(String course){

--- a/src/com/uwflow/flow_android/fragment/CourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseFragment.java
@@ -30,6 +30,7 @@ public class CourseFragment extends Fragment {
     private static final String TAG = "CourseFragment";
 
     private String mCourseID;
+    private CoursePagerAdapter mCoursePagerAdapter;
 
     private View rootView;
     private ViewPager mViewPager;
@@ -69,23 +70,19 @@ public class CourseFragment extends Fragment {
         mTabs = (PagerSlidingTabStrip) rootView.findViewById(R.id.pager_tabs);
 
         mCourseScheduleFragment = new CourseScheduleFragment();
-	mCourseScheduleFragment.setArguments(getArguments());
+        mCourseScheduleFragment.setArguments(getArguments());
         mCourseAboutFragment = new CourseAboutFragment();
-	mCourseAboutFragment.setArguments(getArguments());
+        mCourseAboutFragment.setArguments(getArguments());
         mCourseReviewsFragment = new CourseReviewsFragment();
-	mCourseReviewsFragment.setArguments(getArguments());
+        mCourseReviewsFragment.setArguments(getArguments());
 
-        return rootView;
-    }
+        mCoursePagerAdapter = new CoursePagerAdapter(getChildFragmentManager(),
+                mCourseScheduleFragment,
+                mCourseAboutFragment,
+                mCourseReviewsFragment);
 
-    @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
         mViewPager = (ViewPager) rootView.findViewById(R.id.pager);
-	mViewPager.setAdapter(new CoursePagerAdapter(getActivity().getSupportFragmentManager(),
-		mCourseScheduleFragment,
-		mCourseAboutFragment,
-		mCourseReviewsFragment));
+        mViewPager.setAdapter(mCoursePagerAdapter);
         mTabs.setViewPager(mViewPager);
 
         // Set default tab to About
@@ -113,7 +110,15 @@ public class CourseFragment extends Fragment {
                 startActivity(Intent.createChooser(shareIntent, "Share"));
             }
         });
+
+	    return rootView;
     }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+	super.onViewCreated(view, savedInstanceState);
+    }
+
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState){

--- a/src/com/uwflow/flow_android/fragment/CourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseFragment.java
@@ -29,9 +29,6 @@ import java.util.Map;
 public class CourseFragment extends Fragment {
     private static final String TAG = "CourseFragment";
 
-    private View rootView;
-    protected ViewPager mViewPager;
-    protected PagerSlidingTabStrip mTabs;
     private String mCourseID;
 
     private View rootView;
@@ -72,8 +69,12 @@ public class CourseFragment extends Fragment {
         mTabs = (PagerSlidingTabStrip) rootView.findViewById(R.id.pager_tabs);
 
         mCourseScheduleFragment = new CourseScheduleFragment();
+	mCourseScheduleFragment.setArguments(getArguments());
         mCourseAboutFragment = new CourseAboutFragment();
+	mCourseAboutFragment.setArguments(getArguments());
         mCourseReviewsFragment = new CourseReviewsFragment();
+	mCourseReviewsFragment.setArguments(getArguments());
+
         return rootView;
     }
 

--- a/src/com/uwflow/flow_android/fragment/CourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseFragment.java
@@ -32,7 +32,11 @@ public class CourseFragment extends Fragment {
     private View rootView;
     protected ViewPager mViewPager;
     protected PagerSlidingTabStrip mTabs;
+    private String mCourseID;
 
+    private View rootView;
+    private ViewPager mViewPager;
+    private PagerSlidingTabStrip mTabs;
     private TextView mCourseCodeTextView;
     private TextView mCourseNameTextView;
 
@@ -77,7 +81,10 @@ public class CourseFragment extends Fragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mViewPager = (ViewPager) rootView.findViewById(R.id.pager);
-        mViewPager.setAdapter(new CoursePagerAdapter(getActivity().getSupportFragmentManager(), mCourseScheduleFragment, mCourseAboutFragment, mCourseReviewsFragment));
+	mViewPager.setAdapter(new CoursePagerAdapter(getActivity().getSupportFragmentManager(),
+		mCourseScheduleFragment,
+		mCourseAboutFragment,
+		mCourseReviewsFragment));
         mTabs.setViewPager(mViewPager);
 
         // Set default tab to About
@@ -119,8 +126,8 @@ public class CourseFragment extends Fragment {
         // TODO(david): Should show a spinner here while course info is loading
         Bundle args = getArguments();
         if (args != null) {
-            String courseId = getArguments().getString(Constants.COURSE_ID_KEY);
-            fetchCourseInfo(courseId);
+            mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
+            fetchCourseInfo(mCourseID);
         } else {
             Log.e(TAG, "CourseFragment created without bundle: cannot fetch course details.");
         }

--- a/src/com/uwflow/flow_android/fragment/CourseReviewsFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseReviewsFragment.java
@@ -54,7 +54,7 @@ public class CourseReviewsFragment extends Fragment{
     }
 
     private void reloadReviews() {
-        mCourseReviewListAdapter = new CourseReviewAdapter(mCourseDetail.getReviews(), getActivity());
+	mCourseReviewListAdapter = new CourseReviewAdapter(mCourseDetail.getReviews(), getActivity(), getFragmentManager());
         // clear existing content
         // TODO: we need a smarter way of doing this so that we don't redundantly redraw review objects
         mCourseReviewListContainer.removeAllViews();

--- a/src/com/uwflow/flow_android/fragment/CourseReviewsFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseReviewsFragment.java
@@ -54,7 +54,7 @@ public class CourseReviewsFragment extends Fragment{
     }
 
     private void reloadReviews() {
-	mCourseReviewListAdapter = new CourseReviewAdapter(mCourseDetail.getReviews(), getActivity(), getFragmentManager());
+        mCourseReviewListAdapter = new CourseReviewAdapter(mCourseDetail.getReviews(), getActivity(), getActivity().getSupportFragmentManager());
         // clear existing content
         // TODO: we need a smarter way of doing this so that we don't redundantly redraw review objects
         mCourseReviewListContainer.removeAllViews();

--- a/src/com/uwflow/flow_android/fragment/CourseScheduleFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseScheduleFragment.java
@@ -5,6 +5,7 @@ package com.uwflow.flow_android.fragment;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -24,6 +25,7 @@ import java.util.List;
  * Created by jasperfung on 2/21/14.
  */
 public class CourseScheduleFragment extends Fragment {
+    private static final String TAG = "CourseScheduleFragment";
     private String mCourseID;
 
     private LinearLayout mScheduleContainer;
@@ -34,8 +36,12 @@ public class CourseScheduleFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-	mCourseID = getArguments() != null ? getArguments().getString(Constants.COURSE_ID_KEY,
-		Constants.COURSE_ID_DEFAULT) : Constants.COURSE_ID_DEFAULT;
+        Bundle args = getArguments();
+        if (args != null) {
+            mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
+        } else {
+            Log.e(TAG, "CourseFragment created without bundle: cannot fetch course details.");
+        }
 
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.course_schedule, container, false);
@@ -75,7 +81,7 @@ public class CourseScheduleFragment extends Fragment {
                             // Generate LinearLayouts for every list item
                             String lastTerm = "";
                             for (int i = 0; i < mCourseClassListAdapter.getCount(); i++) {
-                                String currentTerm = DateHelper.formatTermNicely(((Section)mCourseClassListAdapter.getItem(i)).getTermId());
+                                String currentTerm = DateHelper.formatTermNicely(((Section) mCourseClassListAdapter.getItem(i)).getTermId());
                                 if (!currentTerm.equals(lastTerm)) {
                                     // Insert a header for a new term
                                     lastTerm = currentTerm;

--- a/src/com/uwflow/flow_android/fragment/CourseScheduleFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseScheduleFragment.java
@@ -11,20 +11,21 @@ import android.view.ViewGroup;
 import android.widget.*;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.adapters.CourseClassListAdapter;
+import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.db_object.Section;
 import com.uwflow.flow_android.db_object.Sections;
-import com.uwflow.flow_android.entities.CourseClass;
 import com.uwflow.flow_android.network.FlowApiRequestCallbackAdapter;
 import com.uwflow.flow_android.network.FlowApiRequests;
 import com.uwflow.flow_android.util.DateHelper;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Created by jasperfung on 2/21/14.
  */
 public class CourseScheduleFragment extends Fragment {
+    private String mCourseID;
+
     private LinearLayout mScheduleContainer;
     private TableLayout mClassListContainer;
     private TextView mEmptyScheduleView;
@@ -33,61 +34,14 @@ public class CourseScheduleFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+	mCourseID = getArguments() != null ? getArguments().getString(Constants.COURSE_ID_KEY,
+		Constants.COURSE_ID_DEFAULT) : Constants.COURSE_ID_DEFAULT;
+
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.course_schedule, container, false);
         mScheduleContainer = (LinearLayout)rootView.findViewById(R.id.schedule);
         mClassListContainer = (TableLayout)rootView.findViewById(R.id.class_list);
         mEmptyScheduleView = (TextView)rootView.findViewById(R.id.empty_schedule);
-
-
-        // TODO: replace this arraylist with whatever real data source
-        ArrayList<String> daySelection = new ArrayList<String>();
-        daySelection.add("M");
-        daySelection.add("T");
-        daySelection.add("W");
-        daySelection.add("Th");
-        daySelection.add("F");
-        daySelection.add("S");
-        daySelection.add("Su");
-        ArrayList<CourseClass> courseClassList = new ArrayList<CourseClass>();
-        for (int i = 0; i < 5; i++) {
-            String sectionType = "LEC";
-            Integer sectionNum = 1 + i;
-
-            String professor = "Richard Ennis";
-
-            Integer enrollmentTotal = 661 - i * 100;
-            Integer enrollmentCapacity = 675 - i * 100;
-
-            Integer startTimeSeconds = 30600 + i * 3600;
-            Integer endTimeSeconds = 35400 + i * 3600;
-            ArrayList<String> days = new ArrayList<String>();
-            for (int j = 0; j < daySelection.size(); j++) {
-                if (j % (i + 1) == 0) {
-                    days.add(daySelection.get(j));
-                }
-            }
-
-            String building = "RCH";
-            String room = "301";
-            String campus = "UW U";
-
-            courseClassList.add(
-                    new CourseClass(
-                            sectionType,
-                            sectionNum,
-                            professor,
-                            (i % 3 == 0)? enrollmentCapacity : enrollmentTotal,
-                            enrollmentCapacity,
-                            startTimeSeconds,
-                            endTimeSeconds,
-                            days,
-                            building,
-                            room,
-                            campus,
-                            (i % 2 == 0)));
-        }
-
 
         return rootView;
     }
@@ -96,7 +50,7 @@ public class CourseScheduleFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState){
         super.onActivityCreated(savedInstanceState);
 
-        fetchCourseSections("psych101");
+	fetchCourseSections(mCourseID);
     }
 
     private void fetchCourseSections(String course){

--- a/src/com/uwflow/flow_android/fragment/ProfileCourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileCourseFragment.java
@@ -66,7 +66,7 @@ public class ProfileCourseFragment extends Fragment implements LoaderManager.Loa
     private void fetchCourses(String id){
 	if (id == null) return;
 
-	FlowApiRequests.searchUserCourses(
+	FlowApiRequests.getUserCourses(
 		id,
 		new FlowApiRequestCallbackAdapter() {
 		    @Override

--- a/src/com/uwflow/flow_android/fragment/ProfileExamFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileExamFragment.java
@@ -77,7 +77,7 @@ public class ProfileExamFragment extends Fragment implements LoaderManager.Loade
     private void fetchUserExams(String id){
 	if (id == null) return;
 
-	FlowApiRequests.searchUserExams(
+	FlowApiRequests.getUserExams(
 		id,
 		new FlowApiRequestCallbackAdapter() {
 		    @Override

--- a/src/com/uwflow/flow_android/fragment/ProfileExamFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileExamFragment.java
@@ -8,19 +8,24 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
-import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
 import com.uwflow.flow_android.MainFlowActivity;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.adapters.ProfileExamAdapter;
+import com.uwflow.flow_android.adapters.ProfileFriendAdapter;
 import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.db_object.Exam;
+import com.uwflow.flow_android.db_object.Exams;
+import com.uwflow.flow_android.db_object.User;
 import com.uwflow.flow_android.loaders.UserExamsLoader;
+import com.uwflow.flow_android.network.FlowApiRequestCallbackAdapter;
+import com.uwflow.flow_android.network.FlowApiRequests;
 
 import java.util.List;
 
 public class ProfileExamFragment extends Fragment implements LoaderManager.LoaderCallbacks<List<Exam>> {
+    private String mProfileID;
 
     protected ListView mExamsList;
     protected TextView mLastUpdatedText;
@@ -30,6 +35,8 @@ public class ProfileExamFragment extends Fragment implements LoaderManager.Loade
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+	mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
+
         // Inflate the layout for this fragment
         rootView = inflater.inflate(R.layout.profile_exam_layout, container, false);
         mExamsList = (ListView)rootView.findViewById(R.id.exam_list);
@@ -43,7 +50,11 @@ public class ProfileExamFragment extends Fragment implements LoaderManager.Loade
             }
         });
 
-        getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_EXAMS_LOADER_ID, null, this);
+	if (mProfileID == null) {
+	    getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_EXAMS_LOADER_ID, null, this);
+	} else {
+	    fetchUserExams(mProfileID);
+	}
         return rootView;
     }
 
@@ -61,5 +72,22 @@ public class ProfileExamFragment extends Fragment implements LoaderManager.Loade
     @Override
     public void onLoaderReset(Loader<List<Exam>> listLoader) {
         mExamsList.setAdapter(null);
+    }
+
+    private void fetchUserExams(String id){
+	if (id == null) return;
+
+	FlowApiRequests.searchUserExams(
+		id,
+		new FlowApiRequestCallbackAdapter() {
+		    @Override
+		    public void getUserExamsCallback(Exams exams) {
+			List<Exam> examList = exams.getExams();
+
+			profileExamAdapter = new ProfileExamAdapter(examList, getActivity());
+			mExamsList.setAdapter(profileExamAdapter);
+			profileExamAdapter.notifyDataSetChanged();
+		    }
+		});
     }
 }

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -50,7 +50,7 @@ public class ProfileFragment extends Fragment implements LoaderManager.LoaderCal
         userProgram = (TextView) rootView.findViewById(R.id.user_program);
         viewPager = (ViewPager) rootView.findViewById(R.id.pager);
 
-	mProfileID = getArguments().getString(Constants.PROFILE_ID_KEY, "" /* default value */);
+        mProfileID = getArguments().getString(Constants.PROFILE_ID_KEY, "" /* default value */);
 
         getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_LOADER_ID, null, this);
         return rootView;

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -17,15 +17,20 @@ import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
 import com.uwflow.flow_android.MainFlowActivity;
 import com.uwflow.flow_android.R;
+import com.uwflow.flow_android.adapters.ProfileFriendAdapter;
 import com.uwflow.flow_android.adapters.ProfilePagerAdapter;
 import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.db_object.User;
+import com.uwflow.flow_android.db_object.UserFriends;
 import com.uwflow.flow_android.loaders.UserMeLoader;
+import com.uwflow.flow_android.network.FlowApiRequestCallbackAdapter;
+import com.uwflow.flow_android.network.FlowApiRequests;
 
 import java.util.List;
 
 public class ProfileFragment extends Fragment implements LoaderManager.LoaderCallbacks<List<User>> {
     private String mProfileID;
+    private ProfilePagerAdapter mProfilePagerAdapter;
 
     protected ImageView userImage;
     protected TextView userName;
@@ -50,19 +55,28 @@ public class ProfileFragment extends Fragment implements LoaderManager.LoaderCal
         userProgram = (TextView) rootView.findViewById(R.id.user_program);
         viewPager = (ViewPager) rootView.findViewById(R.id.pager);
 
-        mProfileID = getArguments().getString(Constants.PROFILE_ID_KEY, "" /* default value */);
+        mProfilePagerAdapter = new ProfilePagerAdapter(getChildFragmentManager(), getArguments());
 
-        getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_LOADER_ID, null, this);
+        viewPager.setAdapter(mProfilePagerAdapter);
+        tabs = (PagerSlidingTabStrip) rootView.findViewById(R.id.pager_tabs);
+        tabs.setViewPager(viewPager);
+
+        mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
+
+        if (mProfileID == null) {
+            // Load logged-in users profile if an ID is unspecified.
+            getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_LOADER_ID, null, this);
+        }
         return rootView;
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        viewPager.setAdapter(new ProfilePagerAdapter(getActivity().getSupportFragmentManager()));
-        tabs = (PagerSlidingTabStrip) getActivity().findViewById(R.id.pager_tabs);
-        tabs.setViewPager(viewPager);
+
         if (imageBitmap != null) userImage.setImageBitmap(imageBitmap);
+
+        fetchProfileInfo(mProfileID);
     }
 
     @Override
@@ -106,4 +120,41 @@ public class ProfileFragment extends Fragment implements LoaderManager.LoaderCal
     @Override
     public void onLoaderReset(Loader<List<User>> listLoader) {
     }
+
+
+    private void fetchProfileInfo(String id){
+        if (id == null) return;
+
+        FlowApiRequests.getUser(
+                id,
+                new FlowApiRequestCallbackAdapter() {
+                    @Override
+                    public void getUserCallback(User user) {
+
+                        userName.setText(user.getName());
+                        userProgram.setText(user.getProgramName());
+                        Picasso.with(getActivity()).load(user.getProfilePicUrls().getLarge()).into(new Target() {
+                            @Override
+                            public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom loadedFrom) {
+                                if (userImage != null)
+                                    userImage.setImageBitmap(bitmap);
+                                else
+                                    imageBitmap = bitmap;
+                            }
+
+                            @Override
+                            public void onBitmapFailed(Drawable drawable) {
+
+                            }
+
+                            @Override
+                            public void onPrepareLoad(Drawable drawable) {
+
+                            }
+                        });
+                    }
+                });
+    }
+
+
 }

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -25,6 +25,7 @@ import com.uwflow.flow_android.loaders.UserMeLoader;
 import java.util.List;
 
 public class ProfileFragment extends Fragment implements LoaderManager.LoaderCallbacks<List<User>> {
+    private String mProfileID;
 
     protected ImageView userImage;
     protected TextView userName;
@@ -48,6 +49,9 @@ public class ProfileFragment extends Fragment implements LoaderManager.LoaderCal
         userName = (TextView) rootView.findViewById(R.id.user_name);
         userProgram = (TextView) rootView.findViewById(R.id.user_program);
         viewPager = (ViewPager) rootView.findViewById(R.id.pager);
+
+	mProfileID = getArguments().getString(Constants.PROFILE_ID_KEY, "" /* default value */);
+
         getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_LOADER_ID, null, this);
         return rootView;
     }

--- a/src/com/uwflow/flow_android/fragment/ProfileFriendFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFriendFragment.java
@@ -9,35 +9,43 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
+import android.widget.TableLayout;
+import android.widget.TableRow;
 import com.uwflow.flow_android.MainFlowActivity;
 import com.uwflow.flow_android.R;
+import com.uwflow.flow_android.adapters.CourseClassListAdapter;
 import com.uwflow.flow_android.adapters.ProfileFriendAdapter;
 import com.uwflow.flow_android.constant.Constants;
-import com.uwflow.flow_android.db_object.User;
+import com.uwflow.flow_android.db_object.*;
 import com.uwflow.flow_android.loaders.UserFriendsLoader;
+import com.uwflow.flow_android.network.FlowApiRequestCallbackAdapter;
+import com.uwflow.flow_android.network.FlowApiRequests;
+import com.uwflow.flow_android.util.DateHelper;
 
 import java.util.List;
 
 public class ProfileFriendFragment extends Fragment implements LoaderManager.LoaderCallbacks<List<User>>{
-
+    private String mProfileID;
     protected ListView mProfileFriendList;
     protected View rootView;
-    protected ProfileFriendAdapter profileFriendAdapter;
+    protected ProfileFriendAdapter mProfileFriendAdapter;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+	mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
+
         // Inflate the layout for this fragment
         rootView = inflater.inflate(R.layout.profile_friend_layout, container, false);
         mProfileFriendList = (ListView)rootView.findViewById(R.id.friend_list);
 
-        getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_FRIENDS_LOADER_ID, null, this);
-        return rootView;
-    }
+	if (mProfileID == null) {
+	    getLoaderManager().initLoader(Constants.LoaderManagerId.PROFILE_FRIENDS_LOADER_ID, null, this);
+	} else {
+	    fetchFriends(mProfileID);
+	}
 
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState){
-        super.onActivityCreated(savedInstanceState);
+	return rootView;
     }
 
     @Override
@@ -47,12 +55,30 @@ public class ProfileFriendFragment extends Fragment implements LoaderManager.Loa
 
     @Override
     public void onLoadFinished(Loader<List<User>> listLoader, List<User> users) {
-	profileFriendAdapter = new ProfileFriendAdapter(users, getActivity(), getFragmentManager());
-        mProfileFriendList.setAdapter(profileFriendAdapter);
+        mProfileFriendAdapter = new ProfileFriendAdapter(users, getActivity(), getActivity().getSupportFragmentManager());
+        mProfileFriendList.setAdapter(mProfileFriendAdapter);
     }
 
     @Override
     public void onLoaderReset(Loader<List<User>> listLoader) {
         mProfileFriendList.setAdapter(null);
     }
+
+    private void fetchFriends(String id){
+        if (id == null) return;
+
+        FlowApiRequests.getUserFriends(
+                id,
+                new FlowApiRequestCallbackAdapter() {
+                    @Override
+                    public void getUserFriendsCallback(UserFriends userFriends) {
+                        List<User> friendList = userFriends.getFriends();
+
+                        mProfileFriendAdapter = new ProfileFriendAdapter(friendList, getActivity(), getActivity().getSupportFragmentManager());
+                        mProfileFriendList.setAdapter(mProfileFriendAdapter);
+                        mProfileFriendAdapter.notifyDataSetChanged();
+                    }
+                });
+    }
+
 }

--- a/src/com/uwflow/flow_android/fragment/ProfileFriendFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFriendFragment.java
@@ -47,7 +47,7 @@ public class ProfileFriendFragment extends Fragment implements LoaderManager.Loa
 
     @Override
     public void onLoadFinished(Loader<List<User>> listLoader, List<User> users) {
-        profileFriendAdapter = new ProfileFriendAdapter(users, getActivity());
+	profileFriendAdapter = new ProfileFriendAdapter(users, getActivity(), getFragmentManager());
         mProfileFriendList.setAdapter(profileFriendAdapter);
     }
 

--- a/src/com/uwflow/flow_android/fragment/ProfileScheduleFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileScheduleFragment.java
@@ -5,10 +5,15 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.*;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RadioGroup;
 import com.uwflow.flow_android.R;
+import com.uwflow.flow_android.constant.Constants;
 
 public class ProfileScheduleFragment extends Fragment implements View.OnClickListener {
+    private String mProfileID;
 
     private RadioGroup mRadioGroup;
     private ImageView mImageSchedule;
@@ -22,6 +27,8 @@ public class ProfileScheduleFragment extends Fragment implements View.OnClickLis
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+	mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
+
         // Inflate the layout for this fragment
         rootView = inflater.inflate(R.layout.profile_schedule_layout, container, false);
 

--- a/src/com/uwflow/flow_android/util/FacebookUtilities.java
+++ b/src/com/uwflow/flow_android/util/FacebookUtilities.java
@@ -7,9 +7,14 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.util.Log;
 import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.db_object.User;
+import com.uwflow.flow_android.fragment.ProfileFragment;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -47,7 +52,7 @@ public class FacebookUtilities {
         return null;
     }
 
-    public static AlertDialog createUserDialog(final Context context, final User user) {
+    public static AlertDialog createUserDialog(final Context context, final User user, final int resId, final FragmentManager fragmentManager) {
         String firstName = user.getFirstName();
 
         final String[] dialogOptions = {
@@ -69,7 +74,16 @@ public class FacebookUtilities {
                             case 0:
                             default:
                                 // View friend on Flow
-                                // TODO: route to a user's profile on flow
+
+				Fragment profileFragment = new ProfileFragment();
+				Bundle bundle = new Bundle();
+				bundle.putString(Constants.PROFILE_ID_KEY, user.getId());
+				profileFragment.setArguments(bundle);
+
+				FragmentTransaction transaction = fragmentManager.beginTransaction(); // TODO: the fragmentmanager argument is final, this might be problematic
+				transaction.replace(resId, profileFragment);
+				transaction.addToBackStack(null);
+				transaction.commit();
                                 break;
                         }
                         dialog.dismiss();


### PR DESCRIPTION
Several things, mostly stuff to push for demo day:
- Async data fetching via FlowApiRequests for all Profile pages/tabs, similar to the method used in Course pages
- "View $USER on Flow"  on user popup dialogs now links to profile pages
- Fix a bug that was causing our inner fragments to lose state when the outer fragment is replaced (and popped off the backstack)
- Tested to work fully with David's Explore page work
- BUG: For some reason we still can't go >2 layers deep in profile viewing
