### PR TITLE
Changed Image Loader from Picasso to Universal Image loader

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,7 +7,9 @@
               android:targetSdkVersion="18"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
+            android:name=".FlowApplication"
             android:label="@string/app_name"
             android:icon="@drawable/ic_launcher"
             android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,12 @@ dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile 'com.facebook:facebook-android-sdk:+@aar'
     compile 'com.loopj.android:android-async-http:1.4.4'
-    compile 'com.squareup.picasso:picasso:2.2.0'
     compile 'com.astuetz:pagerslidingtabstrip:1.0.1'
     compile 'com.android.support:support-v4:18.0.+'
     compile 'com.google.code.gson:gson:2.1'
     compile 'com.makeramen:roundedimageview:1.2.4'
     compile 'org.apache.commons:commons-lang3:3.1'
+    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.1'
 }
 
 android {

--- a/src/com/uwflow/flow_android/FlowApplication.java
+++ b/src/com/uwflow/flow_android/FlowApplication.java
@@ -1,0 +1,26 @@
+package com.uwflow.flow_android;
+
+import android.app.Application;
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
+import com.uwflow.flow_android.network.FlowAsyncClient;
+
+public class FlowApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // Do init here
+        FlowAsyncClient.init(getApplicationContext());
+        DisplayImageOptions defaultOptions = new DisplayImageOptions.Builder()
+                .cacheInMemory(true)
+                .cacheOnDisc(true)
+                .displayer(new FadeInBitmapDisplayer(300))
+                .build();
+        ImageLoaderConfiguration config = new ImageLoaderConfiguration.Builder(getApplicationContext())
+                .defaultDisplayImageOptions(defaultOptions)
+                .build();
+        ImageLoader.getInstance().init(config);
+    }
+}

--- a/src/com/uwflow/flow_android/LoginActivity.java
+++ b/src/com/uwflow/flow_android/LoginActivity.java
@@ -9,15 +9,9 @@ import com.facebook.Session;
 import com.facebook.model.GraphUser;
 import com.facebook.widget.LoginButton;
 import com.j256.ormlite.android.apptools.OrmLiteBaseActivity;
-import com.j256.ormlite.dao.Dao;
-import com.squareup.picasso.Picasso;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
-import com.uwflow.flow_android.db_object.User;
 import com.uwflow.flow_android.network.*;
-import com.uwflow.flow_android.util.JsonToDbUtil;
 import org.json.JSONObject;
-
-import java.sql.SQLException;
 
 public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
     protected LoginButton loginButton;
@@ -28,7 +22,6 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.login_layout);
-        init();
 
         databaseLoader = new FlowDatabaseLoader(this.getApplicationContext(), getHelper());
         loginButton = (LoginButton) findViewById(R.id.login_button);
@@ -87,9 +80,5 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         Session.getActiveSession().onActivityResult(this, requestCode, resultCode, data);
-    }
-
-    public void init() {
-        FlowAsyncClient.init(this.getApplicationContext());
     }
 }

--- a/src/com/uwflow/flow_android/adapters/CourseReviewAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/CourseReviewAdapter.java
@@ -9,11 +9,11 @@ import android.widget.BaseAdapter;
 import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.TextView;
-import com.squareup.picasso.Picasso;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.db_object.Rating;
 import com.uwflow.flow_android.db_object.Review;
 import com.uwflow.flow_android.fragment.ProfileFragment;
+import com.uwflow.flow_android.network.FlowImageLoader;
 import com.uwflow.flow_android.util.CalendarHelper;
 
 import java.util.Date;
@@ -26,11 +26,13 @@ public class CourseReviewAdapter extends BaseAdapter {
     private List<Review> mReviews;
     private Context mContext;
     private FragmentManager mFragmentManager;
+    private FlowImageLoader flowImageLoader;
 
     public CourseReviewAdapter(List<Review> reviews, Context context, FragmentManager fragmentManager) {
         mReviews = reviews;
         mContext = context;
         mFragmentManager = fragmentManager;
+        flowImageLoader = new FlowImageLoader(context);
     }
 
     public int getCount() {
@@ -87,7 +89,7 @@ public class CourseReviewAdapter extends BaseAdapter {
             first.setText(review.getAuthor().getName());
 
             // Fetch facebook image
-            Picasso.with(mContext).load(review.getAuthor().getProfilePicUrl()).placeholder(R.drawable.kitty).into(image);
+            flowImageLoader.loadImageInto(review.getAuthor().getProfilePicUrl(), image);
 
             // Make this View clickable to go to view that user's profile in our app
             View.OnClickListener onClickListener = new View.OnClickListener() {
@@ -118,7 +120,7 @@ public class CourseReviewAdapter extends BaseAdapter {
             status1.setEnabled(false);
             status1.setChecked(Double.valueOf(usefulRating) == 1);
         }
-        if (easyRating== null) {
+        if (easyRating == null) {
             status2.setEnabled(true);
         } else {
             status2.setEnabled(false);

--- a/src/com/uwflow/flow_android/adapters/FriendListAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/FriendListAdapter.java
@@ -16,9 +16,6 @@ import com.uwflow.flow_android.network.FlowImageLoader;
 
 import java.util.ArrayList;
 
-/**
- * Created by jasperfung on 2/23/14.
- */
 public class FriendListAdapter extends BaseAdapter {
     private ArrayList<CourseFriend> mList;
     private Context mContext;

--- a/src/com/uwflow/flow_android/adapters/FriendListAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/FriendListAdapter.java
@@ -8,11 +8,11 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
-import com.squareup.picasso.Picasso;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.db_object.User;
 import com.uwflow.flow_android.entities.CourseFriend;
 import com.uwflow.flow_android.fragment.ProfileFragment;
+import com.uwflow.flow_android.network.FlowImageLoader;
 
 import java.util.ArrayList;
 
@@ -23,11 +23,13 @@ public class FriendListAdapter extends BaseAdapter {
     private ArrayList<CourseFriend> mList;
     private Context mContext;
     private FragmentManager mFragmentManager;
+    private FlowImageLoader flowImageLoader;
 
     public FriendListAdapter(ArrayList<CourseFriend> list, Context context, FragmentManager fragmentManager) {
         mList = list;
         mContext = context;
 	    mFragmentManager = fragmentManager;
+        flowImageLoader = new FlowImageLoader(context);
     }
 
     public int getCount() {
@@ -64,9 +66,8 @@ public class FriendListAdapter extends BaseAdapter {
         first.setText(user.getName());
         second.setText(mList.get(position).getTermName());
 
-        Picasso.with(mContext).load(user.getProfilePicUrls().getLarge()).placeholder(R.drawable.kitty).into(image);
+        flowImageLoader.loadImageInto(user.getProfilePicUrls().getLarge(), image);
 
-        // Make this View clickable to go to view that user's profile in our app
         View.OnClickListener onClickListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/src/com/uwflow/flow_android/adapters/ProfileFriendAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/ProfileFriendAdapter.java
@@ -62,7 +62,7 @@ public class ProfileFriendAdapter extends BaseAdapter {
             @Override
             public void onClick(View v) {
 		        mFragmentManager.beginTransaction()
-                        .replace(R.id.content_frame, ProfileFragment.newInstance(user.getId()))
+                        .replace(R.id.content_frame, ProfileFragment.newInstance(user))
                         .addToBackStack(null)
                         .commit();
             }

--- a/src/com/uwflow/flow_android/adapters/ProfileFriendAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/ProfileFriendAdapter.java
@@ -8,10 +8,11 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
-import com.squareup.picasso.Picasso;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.db_object.User;
 import com.uwflow.flow_android.fragment.ProfileFragment;
+import com.uwflow.flow_android.network.FlowImageLoader;
+import com.uwflow.flow_android.util.FacebookUtilities;
 
 import java.util.List;
 
@@ -19,11 +20,13 @@ public class ProfileFriendAdapter extends BaseAdapter {
     private List<User> mFriends;
     private Context mContext;
     private FragmentManager mFragmentManager;
+    private FlowImageLoader flowImageLoader;
 
     public ProfileFriendAdapter(List<User> friends, Context context, FragmentManager fragmentManager) {
         mFriends = friends;
         mContext = context;
 	    mFragmentManager = fragmentManager;
+        flowImageLoader = new FlowImageLoader(context);
     }
 
     public int getCount() {
@@ -50,8 +53,8 @@ public class ProfileFriendAdapter extends BaseAdapter {
         first.setText(mFriends.get(position).getName());
         second.setText(mFriends.get(position).getProgramName());
 
-        Picasso.with(mContext).load(mFriends.get(position).getProfilePicUrls().getLarge()).placeholder(R.drawable.kitty).into(image);
 
+        flowImageLoader.loadImageInto(mFriends.get(position).getProfilePicUrls().getLarge(), image);
         final User user = mFriends.get(position);
 
         // Make this View clickable to go to view that user's profile in our app

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -66,7 +66,7 @@ public class Constants {
     // Keys used in bundles
     public static final String PROFILE_ID_KEY = "profileId";
     public static final String COURSE_ID_KEY = "courseId";
-    public static final String USER_ID = "userId";
+    public static final String USER = "userId";
     public static final String TAB_ID = "tabId";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -64,9 +64,10 @@ public class Constants {
     public static final String UW_FLOW = "uwflow";
 
     // Keys used in bundles
-    public static final String COURSE_ID_KEY = "course_id";
-    public static final String PROFILE_ID_KEY = "profile_id";
-    public static final String TAB_ID = "tab_id";
+    public static final String PROFILE_ID_KEY = "profileId";
+    public static final String COURSE_ID_KEY = "courseId";
+    public static final String USER_ID = "userId";
+    public static final String TAB_ID = "tabId";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;
     public static final int COURSE_ABOUT_PAGE_INDEX = 1;

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -68,6 +68,16 @@ public class ProfileFragment extends Fragment {
         return profileFragment;
     }
 
+    public static ProfileFragment newInstance(User user) {
+        ProfileFragment profileFragment = new ProfileFragment();
+
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(Constants.USER, user);
+        profileFragment.setArguments(bundle);
+
+        return profileFragment;
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -79,9 +89,12 @@ public class ProfileFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.profile_layout, container, false);
-        user = getArguments() != null ? (User) getArguments().getSerializable(Constants.USER_ID) : null;
+        user = getArguments() != null ? (User) getArguments().getSerializable(Constants.USER) : null;
         if (user != null)
             mProfileID = user.getId();
+        else
+            mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
+
         flowImageLoader = new FlowImageLoader(getActivity().getApplicationContext());
 
         userImage = (ImageView) rootView.findViewById(R.id.user_image);
@@ -211,6 +224,18 @@ public class ProfileFragment extends Fragment {
     protected void initLoadFromNetwork(final String uid) {
         if (uid == null)
             return;
+        // we might have the cached user data already
+        if (user == null) {
+            FlowApiRequests.getUser(
+                    uid,
+                    new FlowApiRequestCallbackAdapter() {
+                        @Override
+                        public void getUserCallback(User user) {
+                            setUser(user);
+                        }
+                    });
+        }
+
         FlowApiRequests.getUserSchedule(
                 uid,
                 new FlowApiRequestCallbackAdapter() {

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -5,20 +5,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.ViewPager;
-import android.util.Log;
 import android.view.*;
 import android.widget.ImageView;
 import android.widget.TextView;
 import com.astuetz.PagerSlidingTabStrip;
 import com.facebook.*;
 import com.facebook.model.GraphObject;
-import com.squareup.picasso.Picasso;
-import com.squareup.picasso.Target;
 import com.uwflow.flow_android.MainFlowActivity;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.adapters.ProfilePagerAdapter;
@@ -27,6 +23,8 @@ import com.uwflow.flow_android.db_object.*;
 import com.uwflow.flow_android.loaders.*;
 import com.uwflow.flow_android.network.FlowApiRequestCallbackAdapter;
 import com.uwflow.flow_android.network.FlowApiRequests;
+import com.uwflow.flow_android.network.FlowImageLoader;
+import com.uwflow.flow_android.network.FlowImageLoaderCallback;
 import com.uwflow.flow_android.util.FacebookUtilities;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -48,14 +46,15 @@ public class ProfileFragment extends Fragment {
     protected ScheduleCourses userSchedule;
     protected ProfileReceiver profileReceiver;
     protected Bitmap userCover;
-    protected Target coverImageCallback;
-    protected Target imageCallback;
+    protected FlowImageLoaderCallback coverImageCallback;
+    protected FlowImageLoader flowImageLoader;
 
     // only fetch data once
     protected boolean fetchCompleted = false;
 
     /**
      * Static method to instantiate this class with arguments passed as a bundle.
+     *
      * @param userId The ID of the user to show.
      * @return A new instance.
      */
@@ -80,7 +79,10 @@ public class ProfileFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.profile_layout, container, false);
-        mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
+        user = getArguments() != null ? (User) getArguments().getSerializable(Constants.USER_ID) : null;
+        if (user != null)
+            mProfileID = user.getId();
+        flowImageLoader = new FlowImageLoader(getActivity().getApplicationContext());
 
         userImage = (ImageView) rootView.findViewById(R.id.user_image);
         userName = (TextView) rootView.findViewById(R.id.user_name);
@@ -178,25 +180,8 @@ public class ProfileFragment extends Fragment {
 
                                                 new JSONObject((String) json.getString("cover"));
                                         String url = coverObject.getString("source");
-                                        coverImageCallback = new Target() {
-                                            @Override
-                                            public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom loadedFrom) {
-                                                Log.d("BITMAP", "LOADED COVER FROM: " + loadedFrom.toString());
-                                                userCover = bitmap;
-                                                mCoverPhoto.setImageBitmap(userCover);
-                                            }
 
-                                            @Override
-                                            public void onBitmapFailed(Drawable drawable) {
-                                                Log.d("BITMAP", "NOTLOADED");
-                                            }
-
-                                            @Override
-                                            public void onPrepareLoad(Drawable drawable) {
-
-                                            }
-                                        };
-                                        Picasso.with(getActivity().getApplicationContext()).load(url).into(coverImageCallback);
+                                        flowImageLoader.loadImageInto(url, mCoverPhoto);
                                     } catch (JSONException e) {
                                     }
 
@@ -226,15 +211,6 @@ public class ProfileFragment extends Fragment {
     protected void initLoadFromNetwork(final String uid) {
         if (uid == null)
             return;
-        // Get user data
-        FlowApiRequests.getUser(
-                uid,
-                new FlowApiRequestCallbackAdapter() {
-                    @Override
-                    public void getUserCallback(User user) {
-                        setUser(user);
-                    }
-                });
         FlowApiRequests.getUserSchedule(
                 uid,
                 new FlowApiRequestCallbackAdapter() {
@@ -267,27 +243,7 @@ public class ProfileFragment extends Fragment {
         }
 
         fetchCoverPhoto(user.getFbid());
-
-        imageCallback = new Target() {
-            @Override
-            public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom loadedFrom) {
-                userImage.setImageBitmap(bitmap);
-            }
-
-            @Override
-            public void onBitmapFailed(Drawable drawable) {
-
-            }
-
-            @Override
-            public void onPrepareLoad(Drawable drawable) {
-
-            }
-        };
-
-        // Set profile picture
-        Picasso.with(getActivity()).load(user.getProfilePicUrls().getLarge()).into(imageCallback);
-
+        flowImageLoader.loadImageInto(user.getProfilePicUrls().getLarge(), userImage);
         userName.setText(user.getName());
         userProgram.setText(user.getProgramName());
     }

--- a/src/com/uwflow/flow_android/fragment/ProfileScheduleFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileScheduleFragment.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -19,14 +18,13 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RadioGroup;
-import com.squareup.picasso.Picasso;
-import com.squareup.picasso.Target;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.db_object.ScheduleCourses;
+import com.uwflow.flow_android.network.FlowImageLoader;
+import com.uwflow.flow_android.network.FlowImageLoaderCallback;
 
 public class ProfileScheduleFragment extends Fragment implements View.OnClickListener {
-    private String mProfileID;
     private String mScheduleImageURL;
 
     private RadioGroup mRadioGroup;
@@ -38,16 +36,15 @@ public class ProfileScheduleFragment extends Fragment implements View.OnClickLis
     private Bitmap scheduleBitmap;
     private View rootView;
     private ProfileScheduleReceiver profileScheduleReceiver;
-    protected Target scheduleImageCallback;
+    protected FlowImageLoaderCallback scheduleImageCallback;
+    protected FlowImageLoader flowImageLoader;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        mProfileID = getArguments() != null ? getArguments().getString(Constants.PROFILE_ID_KEY) : null;
-
         // Inflate the layout for this fragment
         rootView = inflater.inflate(R.layout.profile_schedule_layout, container, false);
-
+        flowImageLoader = new FlowImageLoader(getActivity().getApplicationContext());
         mRadioGroup = (RadioGroup) rootView.findViewById(R.id.radio_group_view);
         mImageSchedule = (ImageView) rootView.findViewById(R.id.image_schedule);
         mImageSchedule.setOnClickListener(this);
@@ -136,25 +133,14 @@ public class ProfileScheduleFragment extends Fragment implements View.OnClickLis
                 // assume the URL is valid and an image will be returned
                 // TODO: change this conditional to 'if the image is successfully fetched'
                 mScheduleImageURL = scheduleCourses.getScreenshotUrl();
-                scheduleImageCallback = new Target() {
+                scheduleImageCallback = new FlowImageLoaderCallback() {
                     @Override
-                    public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom loadedFrom) {
+                    public void onImageLoaded(Bitmap bitmap) {
                         scheduleBitmap = bitmap;
                         mImageSchedule.setImageBitmap(scheduleBitmap);
                     }
-
-                    @Override
-                    public void onBitmapFailed(Drawable drawable) {
-
-                    }
-
-                    @Override
-                    public void onPrepareLoad(Drawable drawable) {
-
-                    }
                 };
-                Picasso.with(getActivity().getApplicationContext())
-                        .load(mScheduleImageURL).into(scheduleImageCallback);
+                flowImageLoader.loadImage(mScheduleImageURL, scheduleImageCallback);
                 mBtnShare.setEnabled(true);
             }
         }

--- a/src/com/uwflow/flow_android/network/FlowDatabaseLoader.java
+++ b/src/com/uwflow/flow_android/network/FlowDatabaseLoader.java
@@ -81,9 +81,6 @@ public class FlowDatabaseLoader {
                         try {
                             Dao<User, String> userDao = flowDatabaseHelper.getUserDao();
                             for (User u : userFriends.getFriends()) {
-                                if (u.getProfilePicUrls().getLarge() != null){
-                                    flowImageLoader.preloadImage(u.getProfilePicUrls().getLarge());
-                                }
                                 userDao.createOrUpdate(u);
                             }
                         } catch (SQLException e) {
@@ -114,9 +111,6 @@ public class FlowDatabaseLoader {
                     @Override
                     protected Void doInBackground(JSONObject... jsonObjects) {
                         ScheduleCourses scheduleCourses = JsonToDbUtil.getUserSchedule(jsonObjects[0]);
-                        if (scheduleCourses.getScreenshotUrl() != null){
-                            flowImageLoader.preloadImage(scheduleCourses.getScreenshotUrl());
-                        }
                         try {
                             Dao<ScheduleCourse, String> userCourseSchedule = flowDatabaseHelper.getUserScheduleCourseDao();
                             for (ScheduleCourse sc : scheduleCourses.getScheduleCourses()) {

--- a/src/com/uwflow/flow_android/network/FlowDatabaseLoader.java
+++ b/src/com/uwflow/flow_android/network/FlowDatabaseLoader.java
@@ -3,7 +3,6 @@ package com.uwflow.flow_android.network;
 import android.content.Context;
 import android.os.AsyncTask;
 import com.j256.ormlite.dao.Dao;
-import com.squareup.picasso.Picasso;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
 import com.uwflow.flow_android.db_object.*;
 import com.uwflow.flow_android.util.JsonToDbUtil;
@@ -17,10 +16,12 @@ import java.sql.SQLException;
 public class FlowDatabaseLoader {
     protected FlowDatabaseHelper flowDatabaseHelper;
     protected Context context;
+    protected FlowImageLoader flowImageLoader;
 
     public FlowDatabaseLoader(Context context, FlowDatabaseHelper flowDatabaseHelper) {
         this.context = context;
         this.flowDatabaseHelper = flowDatabaseHelper;
+        this.flowImageLoader = new FlowImageLoader(context);
     }
 
     public void loadOrReloadProfileData(ResultCollectorCallback callback) {
@@ -44,7 +45,7 @@ public class FlowDatabaseLoader {
                             Dao<User, String> userDao = flowDatabaseHelper.getUserDao();
                             User user = JsonToDbUtil.getUserMe(jsonObjects[0]);
                             if (user.getProfilePicUrls().getLarge() != null){
-                                Picasso.with(context).load(user.getProfilePicUrls().getLarge()).fetch();
+                                flowImageLoader.preloadImage(user.getProfilePicUrls().getLarge());
                             }
                             if (user != null)
                                 userDao.createOrUpdate(user);
@@ -81,7 +82,7 @@ public class FlowDatabaseLoader {
                             Dao<User, String> userDao = flowDatabaseHelper.getUserDao();
                             for (User u : userFriends.getFriends()) {
                                 if (u.getProfilePicUrls().getLarge() != null){
-                                    Picasso.with(context).load(u.getProfilePicUrls().getLarge()).fetch();
+                                    flowImageLoader.preloadImage(u.getProfilePicUrls().getLarge());
                                 }
                                 userDao.createOrUpdate(u);
                             }
@@ -114,7 +115,7 @@ public class FlowDatabaseLoader {
                     protected Void doInBackground(JSONObject... jsonObjects) {
                         ScheduleCourses scheduleCourses = JsonToDbUtil.getUserSchedule(jsonObjects[0]);
                         if (scheduleCourses.getScreenshotUrl() != null){
-                            Picasso.with(context).load(scheduleCourses.getScreenshotUrl()).fetch();
+                            flowImageLoader.preloadImage(scheduleCourses.getScreenshotUrl());
                         }
                         try {
                             Dao<ScheduleCourse, String> userCourseSchedule = flowDatabaseHelper.getUserScheduleCourseDao();

--- a/src/com/uwflow/flow_android/network/FlowImageLoader.java
+++ b/src/com/uwflow/flow_android/network/FlowImageLoader.java
@@ -1,0 +1,51 @@
+package com.uwflow.flow_android.network;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.view.View;
+import android.widget.ImageView;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.assist.FailReason;
+import com.nostra13.universalimageloader.core.assist.ImageLoadingListener;
+
+public class FlowImageLoader {
+    protected Context context;
+
+    public FlowImageLoader(Context context) {
+        this.context = context;
+    }
+
+    //ONLY CALL THIS IN WORKER THREAD
+    public void preloadImage(String url) {
+        ImageLoader.getInstance().loadImageSync(url);
+    }
+
+    public void loadImage(String url, final FlowImageLoaderCallback callback) {
+        ImageLoader.getInstance().loadImage(url, new ImageLoadingListener() {
+            @Override
+            public void onLoadingStarted(String s, View view) {
+
+            }
+
+            @Override
+            public void onLoadingFailed(String s, View view, FailReason failReason) {
+
+            }
+
+            @Override
+            public void onLoadingComplete(String s, View view, Bitmap bitmap) {
+                if (callback != null)
+                    callback.onImageLoaded(bitmap);
+            }
+
+            @Override
+            public void onLoadingCancelled(String s, View view) {
+
+            }
+        });
+    }
+
+    public void loadImageInto(String url, ImageView imageView) {
+        ImageLoader.getInstance().displayImage(url, imageView);
+    }
+}

--- a/src/com/uwflow/flow_android/network/FlowImageLoaderCallback.java
+++ b/src/com/uwflow/flow_android/network/FlowImageLoaderCallback.java
@@ -1,0 +1,7 @@
+package com.uwflow.flow_android.network;
+
+import android.graphics.Bitmap;
+
+public interface FlowImageLoaderCallback {
+    public void onImageLoaded(Bitmap bitmap);
+}


### PR DESCRIPTION
I've removed Picasso and introduced UIL because it's better at using cache (not reliant on the http header).
Also, moved all image calls into one class so it's easier to maintain in the future.
