### PR TITLE
Prompt user to create account on uwflow.com if new account

### DIFF
--- a/res/layout/login_layout.xml
+++ b/res/layout/login_layout.xml
@@ -13,6 +13,14 @@
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
             />
+    <ProgressBar
+            android:id="@+id/login_progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_marginBottom="100dp"
+            android:layout_centerHorizontal="true"
+            android:visibility="gone"/>
     <Button
             android:id="@+id/skip_login_button"
             android:layout_width="wrap_content"

--- a/src/com/uwflow/flow_android/LoginActivity.java
+++ b/src/com/uwflow/flow_android/LoginActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 import com.facebook.Session;
 import com.facebook.model.GraphUser;
@@ -25,9 +26,11 @@ import org.json.JSONObject;
 public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
     private static final String TAG = "LoginActivity";
 
-    protected LoginButton loginButton;
     protected FlowDatabaseLoader databaseLoader;
-    protected ProgressDialog loadingDialog;
+
+    private LoginButton mLoginButton;
+    private ProgressBar mLoginProgressBar;
+    private Button mSkipLoginButton;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -35,8 +38,12 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
         setContentView(R.layout.login_layout);
 
         databaseLoader = new FlowDatabaseLoader(this.getApplicationContext(), getHelper());
-        loginButton = (LoginButton) findViewById(R.id.login_button);
-        loginButton.setUserInfoChangedCallback(new LoginButton.UserInfoChangedCallback() {
+
+        mLoginProgressBar = (ProgressBar) findViewById(R.id.login_progress_bar);
+        mLoginButton = (LoginButton) findViewById(R.id.login_button);
+        mSkipLoginButton = (Button) findViewById(R.id.skip_login_button);
+
+        mLoginButton.setUserInfoChangedCallback(new LoginButton.UserInfoChangedCallback() {
             @Override
             public void onUserInfoFetched(GraphUser user) {
                 if (user != null) {
@@ -132,18 +139,14 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
             }
         }
 
-        // TODO(david): According to Android UI guidelines, should avoid using a progress dialog. See
-        //     http://developer.android.com/design/building-blocks/progress.html for alternatives
-        loadingDialog = new ProgressDialog(this);
-        loadingDialog.setTitle("Logging In");
-        loadingDialog.setMessage("Loading ...");
-        loadingDialog.setCanceledOnTouchOutside(false);
-        loadingDialog.show();
+        // Indicate loading state and hide other actions
+        mLoginProgressBar.setVisibility(View.VISIBLE);
+        mLoginButton.setVisibility(View.GONE);
+        mSkipLoginButton.setVisibility(View.GONE);
 
         databaseLoader.loadOrReloadProfileData(new ResultCollectorCallback() {
             @Override
             public void loadOrReloadCompleted() {
-                loadingDialog.dismiss();
                 ((FlowApplication)getApplication()).setUserLoggedIn(true);
                 Intent myIntent = new Intent(LoginActivity.this, MainFlowActivity.class);
                 LoginActivity.this.startActivity(myIntent);


### PR DESCRIPTION
If a user tries to log in with Facebook but doesn't already have an account on uwflow.com, we'll show this:

![image](https://f.cloud.github.com/assets/159687/2495922/51759704-b30a-11e3-9087-5489d1e1f56a.png)

Ideally, we would create an account directly on the mobile app, but this involves more work... we'll have to send up basic Facebook info and friends list on every uwflow.com auth request and involves some more API work on the server.

There's also the problem of populating user account data... ideally the user would just do this on desktop, and we don't want to rebuild that flow (of pasting in transcript + schedule) on mobile.
