### PR TITLE
Integrate Crashlytics for error reporting

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -44,6 +44,7 @@
         <activity android:name="com.facebook.LoginActivity"
                   android:screenOrientation="portrait"/>
         <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/app_id"/>
+        <meta-data android:name="com.crashlytics.ApiKey" android:value="0cced89c07497c684c2bd8361b9395d97483cad0"/>
     </application>
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,13 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven { url 'http://download.crashlytics.com/maven' }
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.8+'
+        classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.+'
+
 
     }
 }
@@ -20,9 +24,12 @@ repositories {
     maven {
         url 'https://github.com/astuetz/PagerSlidingTabStrip'
     }
+    maven { url 'http://download.crashlytics.com/maven' }
+
 }
 
 apply plugin: 'android'
+apply plugin: 'crashlytics'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
@@ -35,6 +42,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.1'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.1'
     compile "com.mixpanel.android:mixpanel-android:4.0.0@aar"
+    compile 'com.crashlytics.android:crashlytics:1.+'
 }
 
 android {

--- a/src/com/uwflow/flow_android/FlowApplication.java
+++ b/src/com/uwflow/flow_android/FlowApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
+import com.crashlytics.android.Crashlytics;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
@@ -21,6 +22,8 @@ public class FlowApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        Crashlytics.start(this);
+
         // Do init here
         FlowAsyncClient.init(getApplicationContext());
         DisplayImageOptions defaultOptions = new DisplayImageOptions.Builder()

--- a/src/com/uwflow/flow_android/LoginActivity.java
+++ b/src/com/uwflow/flow_android/LoginActivity.java
@@ -10,12 +10,12 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.Toast;
+import com.crashlytics.android.Crashlytics;
 import com.facebook.Session;
 import com.facebook.model.GraphUser;
 import com.facebook.widget.LoginButton;
 import com.google.analytics.tracking.android.EasyTracker;
 import com.j256.ormlite.android.apptools.OrmLiteBaseActivity;
-import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
 import com.uwflow.flow_android.network.*;
 import org.apache.commons.lang3.StringUtils;
@@ -35,6 +35,7 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         setContentView(R.layout.login_layout);
 
         databaseLoader = new FlowDatabaseLoader(this.getApplicationContext(), getHelper());
@@ -95,7 +96,9 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
                                                     "Oops! Couldn't log into Flow. " + error,
                                                     Toast.LENGTH_LONG)
                                                     .show();
-                                            Log.e(Constants.UW_FLOW, "Error logging in: " + error);
+                                            Log.e(TAG, "Error logging in: " + error);
+
+                                            Crashlytics.log(Log.ERROR, TAG, "Error logging in: " + error);
                                         }
                                     }
                                 });
@@ -171,6 +174,7 @@ public class LoginActivity extends OrmLiteBaseActivity<FlowDatabaseHelper> {
                 FlowAsyncClient.setCsrfToken(csrfToken);
             } catch (JSONException e) {
                 Log.e(TAG, "Could not extract CSRF token from JSON response " + response.toString());
+                Crashlytics.logException(e);
             }
         }
 

--- a/src/com/uwflow/flow_android/dao/FlowDatabaseHelper.java
+++ b/src/com/uwflow/flow_android/dao/FlowDatabaseHelper.java
@@ -3,6 +3,7 @@ package com.uwflow.flow_android.dao;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.android.apptools.OrmLiteSqliteOpenHelper;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.support.ConnectionSource;
@@ -13,6 +14,8 @@ import com.uwflow.flow_android.db_object.*;
 import java.sql.SQLException;
 
 public class FlowDatabaseHelper extends OrmLiteSqliteOpenHelper {
+    private static final String TAG = "FlowDatabaseHelper";
+
     // name of the database file for your application -- change to something appropriate for your app
     private static final String DATABASE_NAME = "flowDatabaseAndroid.db";
 
@@ -45,7 +48,8 @@ public class FlowDatabaseHelper extends OrmLiteSqliteOpenHelper {
             TableUtils.createTable(connectionSource, UserCourse.class);
             TableUtils.createTable(connectionSource, ScheduleImage.class);
         } catch (SQLException e) {
-            Log.e(User.class.getName(), "Unable to create databases", e);
+            Log.e(TAG, "Unable to create databases", e);
+            Crashlytics.logException(e);
         }
     }
 
@@ -60,8 +64,9 @@ public class FlowDatabaseHelper extends OrmLiteSqliteOpenHelper {
             TableUtils.dropTable(connectionSource, ScheduleImage.class, true);
             onCreate(sqLiteDatabase, connectionSource);
         } catch (SQLException e) {
-            Log.e(User.class.getName(), "Unable to upgrade database from version " + oldVer + " to new "
+            Log.e(TAG, "Unable to upgrade database from version " + oldVer + " to new "
                     + newVer, e);
+            Crashlytics.logException(e);
         }
     }
 

--- a/src/com/uwflow/flow_android/fragment/AboutFragment.java
+++ b/src/com/uwflow/flow_android/fragment/AboutFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import com.crashlytics.android.Crashlytics;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.network.FlowImageLoader;
@@ -69,6 +70,7 @@ public class AboutFragment extends TrackedFragment implements View.OnClickListen
                     getActivity().getPackageManager().getPackageInfo(getActivity().getPackageName(), 0).versionName));
         } catch (PackageManager.NameNotFoundException e) {
             Log.e(Constants.UW_FLOW, "Couldn't resolve version name: " + e);
+            Crashlytics.logException(e);
         }
     }
 

--- a/src/com/uwflow/flow_android/fragment/CourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseFragment.java
@@ -19,6 +19,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 import com.astuetz.PagerSlidingTabStrip;
+import com.crashlytics.android.Crashlytics;
 import com.uwflow.flow_android.FlowApplication;
 import com.uwflow.flow_android.MainFlowActivity;
 import com.uwflow.flow_android.R;
@@ -110,7 +111,9 @@ public class CourseFragment extends TrackedFragment {
             mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
             fetchCourseInfo(mCourseID);
         } else {
-            Log.e(TAG, "CourseFragment created without bundle: cannot fetch course details.");
+            String errorLog = "CourseFragment created without bundle: cannot fetch course details.";
+            Log.e(TAG, errorLog);
+            Crashlytics.log(Log.ERROR, TAG, errorLog);
         }
 
         mViewPager = (ViewPager) rootView.findViewById(R.id.pager);

--- a/src/com/uwflow/flow_android/fragment/CourseScheduleFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseScheduleFragment.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
+import com.crashlytics.android.Crashlytics;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.adapters.CourseClassListAdapter;
 import com.uwflow.flow_android.constant.Constants;
@@ -39,9 +40,12 @@ public class CourseScheduleFragment extends TrackedFragment {
 	Bundle args = getArguments();
 	if (args != null) {
 	    mCourseID = getArguments().getString(Constants.COURSE_ID_KEY);
-	} else {
-	    Log.e(TAG, "Attempted instantiation without bundle: cannot fetch course details.");
-	}
+    } else {
+        // TODO(david): Add a FlowLogger class that auto-logs to Crashlytics
+        String errorLog = "Attempted instantiation without bundle: cannot fetch course details.";
+        Log.e(TAG, errorLog);
+        Crashlytics.log(Log.ERROR, TAG, errorLog);
+    }
 
         // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.course_schedule, container, false);

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import com.astuetz.PagerSlidingTabStrip;
 import com.uwflow.flow_android.FlowApplication;
+import com.crashlytics.android.Crashlytics;
 import com.uwflow.flow_android.MainFlowActivity;
 import com.uwflow.flow_android.R;
 import com.uwflow.flow_android.adapters.ProfilePagerAdapter;
@@ -327,6 +328,10 @@ public class ProfileFragment extends TrackedFragment {
             //     return user info on POST /api/v1/login/facebook.
             FlowApplication app = (FlowApplication) getActivity().getApplication();
             app.getMixpanel().identify(user.getId());
+
+            // Send Crashlytics info about current user (may be helpful in communicating/asking for more info)
+            Crashlytics.setUserIdentifier(user.getId());
+            Crashlytics.setUserName(user.getName());
         }
     }
 

--- a/src/com/uwflow/flow_android/loaders/UserCoursesLoader.java
+++ b/src/com/uwflow/flow_android/loaders/UserCoursesLoader.java
@@ -1,10 +1,12 @@
 package com.uwflow.flow_android.loaders;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
-import com.uwflow.flow_android.db_object.*;
+import com.uwflow.flow_android.db_object.Course;
+import com.uwflow.flow_android.db_object.UserCourse;
+import com.uwflow.flow_android.db_object.UserCourseDetail;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -29,6 +31,7 @@ public class UserCoursesLoader extends FlowAbstractDataLoader<UserCourseDetail> 
             userCourseDetail.setUserCourses(userCourses);
         } catch (SQLException e) {
             e.printStackTrace();
+            Crashlytics.logException(e);
         }
         return userCourseDetail;
     }

--- a/src/com/uwflow/flow_android/loaders/UserExamsLoader.java
+++ b/src/com/uwflow/flow_android/loaders/UserExamsLoader.java
@@ -1,15 +1,13 @@
 package com.uwflow.flow_android.loaders;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.stmt.QueryBuilder;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
 import com.uwflow.flow_android.db_object.Exam;
 import com.uwflow.flow_android.db_object.Exams;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class UserExamsLoader extends FlowAbstractDataLoader<Exams> {
@@ -26,6 +24,7 @@ public class UserExamsLoader extends FlowAbstractDataLoader<Exams> {
             exam.setExams(exams);
         } catch (SQLException e) {
             e.printStackTrace();
+            Crashlytics.logException(e);
         }
         return exam;
     }

--- a/src/com/uwflow/flow_android/loaders/UserFriendsLoader.java
+++ b/src/com/uwflow/flow_android/loaders/UserFriendsLoader.java
@@ -2,6 +2,7 @@ package com.uwflow.flow_android.loaders;
 
 import android.content.Context;
 import android.support.v4.app.Fragment;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.stmt.QueryBuilder;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
@@ -30,6 +31,7 @@ public class UserFriendsLoader extends FlowAbstractDataLoader<UserFriends> {
             userFriends = userDao.query(queryBuilder.where().eq(User.IS_ME, false).prepare());
         } catch (SQLException e) {
             e.printStackTrace();
+            Crashlytics.logException(e);
         }
         UserFriends users = new UserFriends();
         users.setFriends(new ArrayList<User>(userFriends));

--- a/src/com/uwflow/flow_android/loaders/UserLoader.java
+++ b/src/com/uwflow/flow_android/loaders/UserLoader.java
@@ -1,14 +1,13 @@
 package com.uwflow.flow_android.loaders;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.stmt.QueryBuilder;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
 import com.uwflow.flow_android.db_object.User;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class UserLoader extends FlowAbstractDataLoader<User> {
@@ -29,6 +28,7 @@ public class UserLoader extends FlowAbstractDataLoader<User> {
             }
         } catch (SQLException e) {
             e.printStackTrace();
+            Crashlytics.logException(e);
         }
         return new User();
     }

--- a/src/com/uwflow/flow_android/loaders/UserScheduleLoader.java
+++ b/src/com/uwflow/flow_android/loaders/UserScheduleLoader.java
@@ -2,6 +2,7 @@ package com.uwflow.flow_android.loaders;
 
 import android.content.Context;
 import android.support.v4.app.Fragment;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
 import com.uwflow.flow_android.dao.FlowDatabaseHelper;
 import com.uwflow.flow_android.db_object.ScheduleCourse;
@@ -30,6 +31,7 @@ public class UserScheduleLoader extends FlowAbstractDataLoader<ScheduleCourses> 
             }
         } catch (SQLException e) {
             e.printStackTrace();
+            Crashlytics.logException(e);
         }
         return scheduleCourses;
     }

--- a/src/com/uwflow/flow_android/network/FlowApiRequests.java
+++ b/src/com/uwflow/flow_android/network/FlowApiRequests.java
@@ -6,6 +6,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.ImageView;
+import com.crashlytics.android.Crashlytics;
 import com.facebook.HttpMethod;
 import com.facebook.Request;
 import com.facebook.Response;
@@ -197,6 +198,7 @@ public class FlowApiRequests {
                                     FlowImageLoader loader = new FlowImageLoader(context);
                                     loader.loadImage(url, imageView, callback);
                                 } catch (Exception e) {
+                                    Crashlytics.logException(e);
                                 }
                             }
                         }
@@ -330,6 +332,7 @@ public class FlowApiRequests {
 
             } catch (Exception e) {
                 callback.onFailure("Failed to parse");
+                Crashlytics.logException(e);
             }
         }
     }

--- a/src/com/uwflow/flow_android/network/FlowDatabaseLoader.java
+++ b/src/com/uwflow/flow_android/network/FlowDatabaseLoader.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.stmt.QueryBuilder;
 import com.uwflow.flow_android.constant.Constants;
@@ -62,6 +63,7 @@ public class FlowDatabaseLoader {
                             }
                         } catch (SQLException e) {
                             e.printStackTrace();
+                            Crashlytics.logException(e);
                         }
                         return null;
                     }
@@ -100,6 +102,7 @@ public class FlowDatabaseLoader {
                     userSchduleImageDao.createOrUpdate(scheduleImages[0]);
                 } catch (SQLException e) {
                     e.printStackTrace();
+                    Crashlytics.logException(e);
                 }
                 return null;
             }
@@ -122,6 +125,7 @@ public class FlowDatabaseLoader {
                             }
                         } catch (SQLException e) {
                             e.printStackTrace();
+                            Crashlytics.logException(e);
                         }
                         return null;
                     }
@@ -156,6 +160,7 @@ public class FlowDatabaseLoader {
                             }
                         } catch (SQLException e) {
                             e.printStackTrace();
+                            Crashlytics.logException(e);
                         }
                         return null;
                     }
@@ -190,6 +195,7 @@ public class FlowDatabaseLoader {
                             }
                         } catch (SQLException e) {
                             e.printStackTrace();
+                            Crashlytics.logException(e);
                         }
                         return null;
                     }
@@ -229,6 +235,7 @@ public class FlowDatabaseLoader {
                             }
                         } catch (SQLException e) {
                             e.printStackTrace();
+                            Crashlytics.logException(e);
                         }
                         return null;
                     }
@@ -266,6 +273,7 @@ public class FlowDatabaseLoader {
                     if (!images.isEmpty())
                         return images.get(0);
                 } catch (Exception e) {
+                    Crashlytics.logException(e);
                 }
                 return null;
             }

--- a/src/com/uwflow/flow_android/network/FlowResultCollector.java
+++ b/src/com/uwflow/flow_android/network/FlowResultCollector.java
@@ -2,6 +2,7 @@ package com.uwflow.flow_android.network;
 
 import android.os.AsyncTask;
 import android.util.Log;
+import com.crashlytics.android.Crashlytics;
 
 /**
  * This class is used to sync multiple async results
@@ -57,6 +58,7 @@ public class FlowResultCollector {
                     Thread.sleep(8000);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
+                    Crashlytics.logException(e);
                 }
                 return null;
             }

--- a/src/com/uwflow/flow_android/util/FacebookUtilities.java
+++ b/src/com/uwflow/flow_android/util/FacebookUtilities.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.util.Log;
+import com.crashlytics.android.Crashlytics;
 import com.uwflow.flow_android.constant.Constants;
 
 import java.io.IOException;
@@ -43,8 +44,10 @@ public class FacebookUtilities {
                 return bitmap;
             } catch (MalformedURLException e) {
                 Log.e(Constants.UW_FLOW, "Error creating image URL: " + e);
+                Crashlytics.logException(e);
             } catch (IOException e) {
                 Log.e(Constants.UW_FLOW, "Error opening connection during image fetch: " + e);
+                Crashlytics.logException(e);
             }
         }
         return null;


### PR DESCRIPTION
From what I've gathered Crashlytics seems to be the best offering in the Android crash reporting landscape. Additionally, it's completely free because they were acquired by Twitter and they made their Enterprise edition free, no limits.

I've sent all of you guys invites. Check your inbox.
## Test plan

Hit a known bug that causes crashes (which I just discovered recently): click the loading spinner on the explore page.

Here's what the Crashlytics dashboard shows:

![image](https://f.cloud.github.com/assets/159687/2520779/2554ac8c-b495-11e3-96ab-64dab112ed42.png)

(Yes, I did crash the app three times.)
