### PR TITLE
NFC sharing for Course and Profile Fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ out/
 .gradle/
 
 build/
+# crashlytics build identification
+res/values/com_crashlytics_export_strings.xml

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.NFC" />
 
     <!-- Required by Google Analytics and Mixpanel -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -37,6 +38,13 @@
         <activity android:name=".MainFlowActivity"
                   android:screenOrientation="portrait"
                   android:theme="@style/Flow.Styled">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="https"
+                      android:host="uwflow.com"
+                      android:pathPattern=".*" />
+            </intent-filter>
         </activity>
         <activity android:name=".activities.FullScreenImageActivity"
                   android:screenOrientation="portrait">

--- a/src/com/uwflow/flow_android/MainFlowActivity.java
+++ b/src/com/uwflow/flow_android/MainFlowActivity.java
@@ -30,6 +30,8 @@ import com.uwflow.flow_android.fragment.ExploreFragment;
 import com.uwflow.flow_android.fragment.ProfileFragment;
 import com.uwflow.flow_android.network.FlowAsyncClient;
 import com.uwflow.flow_android.nfc.SharableURL;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 
@@ -179,8 +181,12 @@ public class MainFlowActivity extends FlowActivity {
                         );
 
                         JSONObject properties = new JSONObject();
-                        properties.put("uri", url);
-                        ((FlowApplication) getApplication()).track("NFC push event: ", properties);
+                        try {
+                            properties.put("uri", url);
+                        } catch (JSONException e) {
+                            e.printStackTrace();
+                        }
+                        ((FlowApplication) getApplication()).track("NFC push event", properties);
 
                         return msg;
                     }
@@ -338,8 +344,12 @@ public class MainFlowActivity extends FlowActivity {
                 }
 
                 JSONObject properties = new JSONObject();
-                properties.put("uri", payload);
-                ((FlowApplication) getApplication()).track("NFC receive event: ", properties);
+                try {
+                    properties.put("uri", payload);
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+                ((FlowApplication) getApplication()).track("NFC receive event", properties);
             }
         }
     }

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -72,7 +72,6 @@ public class Constants {
     // Keys used in bundles
     public static final String PROFILE_ID_KEY = "profileId";
     public static final String COURSE_ID_KEY = "courseId";
-    public static final String USER_KEY = "userId";
     public static final String TAB_ID_KEY = "tabId";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -2,9 +2,13 @@ package com.uwflow.flow_android.constant;
 
 public class Constants {
     public static final String SESSION_COOKIE_DOMAIN = "uwflow.com";
+    public static final String FLOW_DOMAIN = "uwflow.com";
     public static final String BASE_URL = "https://uwflow.com/";
     public static final String FBID = "fbid";
     public static final String FACEBOOK_ACCESS_TOKEN = "fb_access_token";
+
+    public static final String URL_PROFILE_EXT = "profile/";
+    public static final String URL_COURSE_EXT = "course/";
 
     public static final String API_LOGIN = "api/v1/login/facebook";
     public static final String API_COURSE = "api/v1/courses/%s";
@@ -68,8 +72,8 @@ public class Constants {
     // Keys used in bundles
     public static final String PROFILE_ID_KEY = "profileId";
     public static final String COURSE_ID_KEY = "courseId";
-    public static final String USER = "userId";
-    public static final String TAB_ID = "tabId";
+    public static final String USER_KEY = "userId";
+    public static final String TAB_ID_KEY = "tabId";
 
     public static final int COURSE_SCHEDULE_PAGE_INDEX = 0;
     public static final int COURSE_ABOUT_PAGE_INDEX = 1;

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -1,8 +1,8 @@
 package com.uwflow.flow_android.constant;
 
 public class Constants {
-    public static final String SESSION_COOKIE_DOMAIN = "uwflow.com";
     public static final String FLOW_DOMAIN = "uwflow.com";
+    public static final String SESSION_COOKIE_DOMAIN = FLOW_DOMAIN;
     public static final String BASE_URL = "https://uwflow.com/";
     public static final String FBID = "fbid";
     public static final String FACEBOOK_ACCESS_TOKEN = "fb_access_token";

--- a/src/com/uwflow/flow_android/fragment/CourseFragment.java
+++ b/src/com/uwflow/flow_android/fragment/CourseFragment.java
@@ -32,13 +32,15 @@ import com.uwflow.flow_android.network.FlowApiRequestCallback;
 import com.uwflow.flow_android.network.FlowApiRequestCallbackAdapter;
 import com.uwflow.flow_android.network.FlowApiRequests;
 import com.uwflow.flow_android.util.CourseUtil;
+import com.uwflow.flow_android.nfc.*;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
  * Created by jasperfung on 2/21/14.
  */
-public class CourseFragment extends TrackedFragment {
+public class CourseFragment extends TrackedFragment implements SharableURL {
     private static final String TAG = "CourseFragment";
 
     private String mCourseID;
@@ -216,6 +218,14 @@ public class CourseFragment extends TrackedFragment {
     public void onPause() {
         LocalBroadcastManager.getInstance(this.getActivity().getApplicationContext()).unregisterReceiver(courseUpdateReceiver);
         super.onPause();
+    }
+
+    @Override
+    public String getUrl() {
+        if (StringUtils.isEmpty(mCourseID)) {
+            return null;
+        }
+        return Constants.BASE_URL + Constants.URL_COURSE_EXT + mCourseID;
     }
 
     private void fetchCourseInfo(String course) {

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -114,13 +114,9 @@ public class ProfileFragment extends TrackedFragment implements SharableURL {
         }
 
         init();
+
         if (getArguments() != null) {
-            final Bundle args = getArguments();
-            setUser((User) args.getSerializable(Constants.USER_KEY));
-            if (user != null)
-                mProfileID = user.getId();
-            else
-                mProfileID = getArguments() != null ? args.getString(Constants.PROFILE_ID_KEY) : null;
+            mProfileID = getArguments().getString(Constants.PROFILE_ID_KEY);
         }
 
         profilePagerAdapter = new ProfilePagerAdapter(getChildFragmentManager(), getArguments(), mProfileID == null);

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -1,10 +1,8 @@
 package com.uwflow.flow_android.fragment;
 
+import android.app.AlertDialog;
 import android.app.ProgressDialog;
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
+import android.content.*;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -23,9 +21,11 @@ import com.uwflow.flow_android.constant.Constants;
 import com.uwflow.flow_android.db_object.*;
 import com.uwflow.flow_android.loaders.*;
 import com.uwflow.flow_android.network.*;
+import com.uwflow.flow_android.nfc.SharableURL;
 import com.uwflow.flow_android.util.FacebookUtilities;
+import org.apache.commons.lang3.StringUtils;
 
-public class ProfileFragment extends TrackedFragment {
+public class ProfileFragment extends TrackedFragment implements SharableURL {
     private String mProfileID;
     private ProfilePagerAdapter profilePagerAdapter;
 
@@ -67,7 +67,7 @@ public class ProfileFragment extends TrackedFragment {
 
         Bundle bundle = new Bundle();
         if (tabID != null) {
-            bundle.putInt(Constants.TAB_ID, tabID);
+            bundle.putInt(Constants.TAB_ID_KEY, tabID);
         }
         if (userID != null) {
             bundle.putString(Constants.PROFILE_ID_KEY, userID);
@@ -105,7 +105,7 @@ public class ProfileFragment extends TrackedFragment {
         // Note: this is sorta cheating. We might need to decrease this number so that we don't run into memory issues.
         viewPager.setOffscreenPageLimit(3);
 
-        Integer tabID = getArguments() != null? getArguments().getInt(Constants.TAB_ID) : null;
+        Integer tabID = getArguments() != null ? getArguments().getInt(Constants.TAB_ID_KEY) : null;
         if (tabID == null) {
             // Set default tab to Schedule
             viewPager.setCurrentItem(Constants.PROFILE_SCHEDULE_PAGE_INDEX);
@@ -116,7 +116,7 @@ public class ProfileFragment extends TrackedFragment {
         init();
         if (getArguments() != null) {
             final Bundle args = getArguments();
-            setUser((User) args.getSerializable(Constants.USER));
+            setUser((User) args.getSerializable(Constants.USER_KEY));
             if (user != null)
                 mProfileID = user.getId();
             else
@@ -189,6 +189,14 @@ public class ProfileFragment extends TrackedFragment {
         super.onPause();
     }
 
+    @Override
+    public String getUrl() {
+        if (user == null || StringUtils.isEmpty(user.getId())) {
+            return null;
+        }
+        return Constants.BASE_URL + Constants.URL_PROFILE_EXT + user.getId();
+    }
+
     protected void initLoaders() {
         final UserLoaderCallback userLoader = new UserLoaderCallback(getActivity().getApplicationContext(), this, ((MainFlowActivity) getActivity()).getHelper());
         final UserFriendsLoaderCallback userFriendsLoader = new UserFriendsLoaderCallback(getActivity().getApplicationContext(), this, ((MainFlowActivity) getActivity()).getHelper());
@@ -233,6 +241,29 @@ public class ProfileFragment extends TrackedFragment {
                         @Override
                         public void onFailure(String error) {
                             if (collector != null) collector.setState(0, true);
+
+                            /*
+                             * ATM we don't have a way to see if there was a 403 Forbidden response, which indicates
+                             * that the logged-in user cannot access the profile being requested (not a FB friend).
+                             * We're assuming that is the case here in onFailure.
+                             * TODO: confirm the error before creating this explanation dialog.
+                             */
+                            AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
+                                    .setTitle("Uh-Oh!")
+                                    .setMessage("You need to be a Facebook friend of this user to view their profile.")
+                                    .setNegativeButton("Go back", new DialogInterface.OnClickListener() {
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            // Pop fragment.
+                                            getFragmentManager().popBackStackImmediate();
+                                        }
+                                    })
+                                    .setCancelable(false)
+                                    .show();
+
+                            // Log unauthorized profile access event.
+                            JSONObject properties = new JSONObject();
+                            properties.put("requestedProfileID", mProfileID);
+                            ((FlowApplication) getApplication()).track("Unauthorized profile access", properties);
                         }
                     });
         }
@@ -341,8 +372,9 @@ public class ProfileFragment extends TrackedFragment {
     }
 
     public void setUser(User user) {
-        if (user == null)
+        if (user == null) {
             return;
+        }
         this.user = user;
         if (userCover == null && user.getFbid() != null) {
             FlowApiRequests.getUserCoverImage(this.getActivity().getApplicationContext(), user.getFbid(), coverPhotoImageView,

--- a/src/com/uwflow/flow_android/fragment/ProfileFragment.java
+++ b/src/com/uwflow/flow_android/fragment/ProfileFragment.java
@@ -259,7 +259,8 @@ public class ProfileFragment extends TrackedFragment implements SharableURL {
                             // Log unauthorized profile access event.
                             JSONObject properties = new JSONObject();
                             properties.put("requestedProfileID", mProfileID);
-                            ((FlowApplication) getApplication()).track("Unauthorized profile access", properties);
+                            ((FlowApplication) getActivity().getApplication())
+                                    .track("Unauthorized profile access", properties);
                         }
                     });
         }

--- a/src/com/uwflow/flow_android/nfc/SharableURL.java
+++ b/src/com/uwflow/flow_android/nfc/SharableURL.java
@@ -1,0 +1,12 @@
+package com.uwflow.flow_android.nfc;
+
+/*
+ * Interface to implement for anything with an associated URL
+ */
+public interface SharableURL {
+    /*
+     * Get URL associated with the implementing class
+     */
+    public String getUrl();
+}
+


### PR DESCRIPTION
Note: Currently we share whatever is on the screen, be it a friend’s
Profile or yours. The alternative is to always share the logged-in
user’s profile if they are on any Profile screen.

Also, we’re currently using intent filters to handle NFC intents so
that we can trigger our choice of Activity (MainFlowActivity) rather
than the application default (LoginActivity). I mention this because
someone who touches this NFC code in the future may be inclined to use
Android Application Record (AAR) in the NFC push messages
(NDefMessage). This is not what we want, at least in it’s current
implementation (API 18) because “AARs are only supported at the
application level, because of the package name constraint, and not at
the Activity level as with intent filtering.” (quoted from
http://developer.android.com/guide/topics/connectivity/nfc/nfc.html#aar)
. In other words, specifying AAR means opening the LoginActivity when
we receive a Flow NFC event.
