### PR TITLE
Configure gradle to generate signed release APK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ out/
 .gradle/
 
 build/
+
+# Android APK-signing keystore
+flow-android-release-key.keystore
+
+# Passwords and keys and such
+secrets.properties

--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,27 @@ android {
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')
     }
+
+    // Configure release certificate signing if the secrets.properties file exists
+    if (file("secrets.properties").exists()) {
+        Properties props = new Properties();
+        props.load(new FileInputStream(file("secrets.properties")))
+
+        signingConfigs {
+            release {
+                storeFile file(props['release.storeFile'])
+                storePassword props['release.storePassword']
+                keyAlias props['release.keyAlias']
+                keyPassword props['release.keyPassword']
+            }
+        }
+
+        buildTypes {
+            release {
+                signingConfig signingConfigs.release
+            }
+        }
+    } else {
+        System.out.println("File 'secrets.properties' not found. Will not generate signed release APK.");
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,8 @@ android {
         buildTypes {
             release {
                 signingConfig signingConfigs.release
+                runProguard true
+                proguardFile getDefaultProguardFile('proguard-android.txt')
             }
         }
     } else {


### PR DESCRIPTION
To generate a signed release APK that can be published on the Play store:
1. Ensure you have the key used for signing, `flow-android-release-key.keystore`, and put that in your project root directory. This file is not checked in.
2. Ensure you have `secrets.properties` in your project root directory. This file contains keys and passwords for the certificate. This file is also not checked in.
3. Run the Gradle task `assembleRelease`.
4. Find the signed aligned APK in `flow-android/build/apk/flow-android-release.apk`. You can now upload this to the Google Play Store.

If the files in 1 and 2 are missing, this will gracefully degrade to not generating a signed release APK. Everything else still works as is, including building and loading a debug apk to emulator/phone.
