### PR TITLE
Refactor Nav Drawer code

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="drawer_open">Open</string>
     <string name="drawer_close">Close</string>
 
+    <string name="drawer_item_profile">Profile</string>
+    <string name="drawer_item_explore">Explore</string>
+    <string name="drawer_item_about">About</string>
+
     <string name="explore_sort_prompt">Sort by…</string>
 
     <string name="skip_login_text"><u>Or skip login</u></string>

--- a/src/com/uwflow/flow_android/adapters/NavDrawerAdapter.java
+++ b/src/com/uwflow/flow_android/adapters/NavDrawerAdapter.java
@@ -31,8 +31,16 @@ public class NavDrawerAdapter extends BaseAdapter {
     }
 
     public long getItemId(int position) {
-        // TODO Auto-generated method stub
-        return position;
+        return ((NavDrawerItem)getItem(position)).getId();
+    }
+
+    public int getPositionFromId(int id) {
+        for (int i = 0; i < navDrawerItemList.size(); i++) {
+            if (navDrawerItemList.get(i).getId() == id) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     public View getView(int position, View convertView, ViewGroup parent) {

--- a/src/com/uwflow/flow_android/constant/Constants.java
+++ b/src/com/uwflow/flow_android/constant/Constants.java
@@ -89,6 +89,11 @@ public class Constants {
     public static final int PROFILE_COURSES_PAGE_INDEX = 2;
     public static final int PROFILE_EXAMS_PAGE_INDEX = 3;
 
+    public static final int NAV_DRAWER_PROFILE_INDEX = 0;
+    public static final int NAV_DRAWER_EXPLORE_INDEX = 1;
+    public static final int NAV_DRAWER_SHORTLIST_INDEX = 2;
+    public static final int NAV_DRAWER_ABOUT_INDEX = 3;
+
     public static final String FBID_DAVID = "541400376";
     public static final String FBID_JASPER = "505131734";
     public static final String FBID_WENTAO = "100000580776460";

--- a/src/com/uwflow/flow_android/entities/NavDrawerItem.java
+++ b/src/com/uwflow/flow_android/entities/NavDrawerItem.java
@@ -4,12 +4,22 @@ package com.uwflow.flow_android.entities;
  * Created by jasperfung on 2/28/14.
  */
 public class NavDrawerItem {
+    private int id;
     private String name;
     private int iconResID;
 
-    public NavDrawerItem(String name, int iconResID) {
+    public NavDrawerItem(int id, String name, int iconResID) {
+        this.id = id;
         this.name = name;
         this.iconResID = iconResID;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
     }
 
     public String getName() {


### PR DESCRIPTION
- Removed redundant fragment replacement code (now all housed in
  MainFlowFragment.selectItem(int itemId))
- Moved some strings to resources
- Close drawer and do nothing on attempts to open redundant fragments
  (i.e. clicking Profile when your profile is already onscreen)
- Clicking Search via ActionBar will trigger the Explore Nav Drawer item
